### PR TITLE
addresses mysql2 issue with empty column_types on select statements

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -160,7 +160,7 @@ module Blazer
           result.each do |untyped_row|
             row = {}
             untyped_row.each do |k, v|
-              row[k] = result.column_types[k].send(:type_cast, v)
+              row[k] = result.column_types.empty? ? v : result.column_types[k].send(:type_cast, v)
             end
             rows << row
           end


### PR DESCRIPTION
the mysql2 adapter currently can't be used with Blazer.  Seems to be an issue that mysql2 directly run sql statements `Blazer::Connection.select(statement)` returns empty column_types.   A simple patch to not type_cast the data when column_types are empty allows basic functionality