### PR TITLE
Use secrets.yml instead of ENV directly

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -129,7 +129,7 @@ module Blazer
     private
 
     def ensure_database_url
-      render text: "BLAZER_DATABASE_URL required" if !ENV["BLAZER_DATABASE_URL"] && !Rails.env.development?
+      render text: "BLAZER_DATABASE_URL required" if !Rails.application.secrets[:blazer_database_url] && !Rails.env.development?
     end
 
     def set_query

--- a/app/models/blazer/connection.rb
+++ b/app/models/blazer/connection.rb
@@ -1,6 +1,6 @@
 module Blazer
   class Connection < ActiveRecord::Base
-    establish_connection ENV["BLAZER_DATABASE_URL"] if ENV["BLAZER_DATABASE_URL"]
+    establish_connection Rails.application.secrets[:blazer_database_url] if Rails.application.secrets[:blazer_database_url]
     self.abstract_class = true
   end
 end


### PR DESCRIPTION
Found it easier to use secrets.yml instead of trying to set ENV variables for all our settings.