### PR TITLE
fix for json_escape prior to versions 4.1 of rails

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -1,5 +1,7 @@
 module Blazer
   module BaseHelper
+    include BlazerJsonEscape
+
     def title(title = nil)
       if title
         content_for(:title) { title }

--- a/app/views/blazer/checks/run.html.erb
+++ b/app/views/blazer/checks/run.html.erb
@@ -1,7 +1,7 @@
 <p style="text-muted">Running check...</p>
 
 <script>
-  $.post("<%= run_queries_path %>", <%= json_escape({statement: @query.statement, query_id: @query.id, check: true}.to_json).html_safe %>, function (data) {
+  $.post("<%= run_queries_path %>", <%= blazer_json_escape({statement: @query.statement, query_id: @query.id, check: true}.to_json).html_safe %>, function (data) {
     setTimeout( function () {
       window.location.href = "<%= checks_path %>";
     }, 200);

--- a/app/views/blazer/dashboards/show.html.erb
+++ b/app/views/blazer/dashboards/show.html.erb
@@ -137,7 +137,7 @@
     var request = $.ajax({
       url: "<%= run_queries_path %>",
       method: "POST",
-      data: <%= json_escape({statement: query.statement, query_id: query.id, only_chart: true}.to_json).html_safe %>,
+      data: <%= blazer_json_escape({statement: query.statement, query_id: query.id, only_chart: true}.to_json).html_safe %>,
       dataType: "html"
     }).done(function(data) {
       $("#chart-<%= i %>").html(data);

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -97,7 +97,7 @@
 
   var error_line = null;
   var xhr;
-  var params = <%= raw json_escape(variable_params.to_json) %>;
+  var params = <%= raw blazer_json_escape(variable_params.to_json) %>;
 
   $("#run").click(function (e) {
     e.preventDefault();

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -158,7 +158,7 @@
     var request = $.ajax({
       url: "<%= run_queries_path %>",
       method: "POST",
-      data: <%= json_escape(variable_params.merge(statement: @statement, query_id: @query.id).to_json).html_safe %>,
+      data: <%= blazer_json_escape(variable_params.merge(statement: @statement, query_id: @query.id).to_json).html_safe %>,
       dataType: "html"
     }).done(function(data) {
       $("#results").html(data);

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -4,6 +4,7 @@ require "blazer/version"
 require "blazer/data_source"
 require "blazer/engine"
 require "blazer/tasks"
+require "rails_extensions/blazer_json_escape"
 
 module Blazer
   class << self

--- a/lib/rails_extensions/blazer_json_escape.rb
+++ b/lib/rails_extensions/blazer_json_escape.rb
@@ -1,0 +1,15 @@
+module BlazerJsonEscape
+  JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
+  JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
+
+  # Prior to version 4.1 of rails double quotes were inadventently removed in json_escape.
+  # This adds the correct json_escape functionality to rails versions < 4.1
+  def blazer_json_escape(s)
+    if Rails::VERSION::STRING < "4.1"
+      result = s.to_s.gsub(JSON_ESCAPE_REGEXP, JSON_ESCAPE)
+      s.html_safe? ? result.html_safe : result
+    else
+      json_escape(s)
+    end
+  end
+end


### PR DESCRIPTION
change name of json_escape patch method to blazer_json_escape
call json_escape not super