### PR TITLE
Avoid overwriting default protect_from_forgery behaviour

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -3,8 +3,6 @@ module Blazer
     # skip all filters
     skip_filter *_process_action_callbacks.map(&:filter)
 
-    protect_from_forgery with: :exception
-
     if ENV["BLAZER_PASSWORD"]
       http_basic_authenticate_with name: ENV["BLAZER_USERNAME"], password: ENV["BLAZER_PASSWORD"]
     end


### PR DESCRIPTION
It makes sense to respect the default behaviour typically defined in the ApplicationController rather than overwrite it. In particular, in API-only apps this leads to https://github.com/ankane/blazer/issues/35
