### PR TITLE
Prevent accidental backspace navigation on query edit page

### DIFF
--- a/app/assets/javascripts/blazer/application.js
+++ b/app/assets/javascripts/blazer/application.js
@@ -22,4 +22,34 @@ $( function () {
   $('.dropdown-toggle').mouseenter( function () {
     $(this).parent().addClass('open');
   });
+
+  // Prevent backspace from navigating backwards.
+  // Adapted from Biff MaGriff: http://stackoverflow.com/a/7895814/1196499
+  $("body.disable-backspace-nav").closest(document).keydown(function (e) {
+    var preventKeyPress;
+    if (e.keyCode == 8) {
+      var d = e.srcElement || e.target;
+      switch (d.tagName.toUpperCase()) {
+        case 'TEXTAREA':
+          preventKeyPress = d.readOnly || d.disabled;
+          break;
+        case 'INPUT':
+          preventKeyPress = d.readOnly || d.disabled || (d.attributes["type"] && $.inArray(d.attributes["type"].value.toLowerCase(), ["radio", "reset", "checkbox", "submit", "button"]) >= 0);
+          break;
+        case 'DIV':
+          preventKeyPress = d.readOnly || d.disabled || !(d.attributes["contentEditable"] && d.attributes["contentEditable"].value == "true");
+          break;
+        default:
+          preventKeyPress = true;
+          break;
+      }
+    }
+    else {
+      preventKeyPress = false;
+    }
+
+    if (preventKeyPress) {
+      e.preventDefault();
+    }
+  });
 });

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -1,3 +1,5 @@
+<% content_for :body_class, "disable-backspace-nav" %>
+
 <% if @query.errors.any? %>
   <div class="alert alert-danger"><%= @query.errors.full_messages.first %></div>
 <% end %>

--- a/app/views/layouts/blazer/application.html.erb
+++ b/app/views/layouts/blazer/application.html.erb
@@ -13,7 +13,7 @@
     <% end %>
     <%= csrf_meta_tags %>
   </head>
-  <body>
+  <body class="<%= yield(:body_class) || "" %>">
     <div class="container">
       <%= yield %>
     </div>


### PR DESCRIPTION
When editing a query I often mistakenly think the text area has focus and hit backspace (delete). This navigates me back to the previous page and away from a very gorgeous and very unsaved query.

The code in this PR prevents backspaces (deletes) from doing that. (Only on the edit query page.)