### PR TITLE
Preserve columns with the same name

### DIFF
--- a/app/controllers/blazer/dashboards_controller.rb
+++ b/app/controllers/blazer/dashboards_controller.rb
@@ -34,7 +34,7 @@ module Blazer
         @data_sources.each do |data_source|
           query = data_source.smart_variables[var]
           if query
-            rows, error, cached_at = data_source.run_statement(query)
+            columns, rows, error, cached_at = data_source.run_statement(query)
             ((@smart_vars[var] ||= []).concat(rows.map { |v| v.values.reverse })).uniq!
             @sql_errors << error if error
           end

--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -17,9 +17,9 @@ module Blazer
     end
 
     def blazer_column_types(columns, rows, boom)
-      columns.map do |k, _|
-        v = (rows.find { |r| r[k] } || {})[k]
-        if boom[k]
+      columns.map do |column|
+        v = (rows.find { |r| r[column[:name]] } || {})[column[:name]]
+        if boom[column[:name]]
           "string"
         elsif v.is_a?(Numeric)
           "numeric"

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -60,9 +60,9 @@
       <% time_k = @columns.first[:name] %>
       <%= line_chart @columns[1..-1].map{|column| {name: column[:name], data: @rows.map{|r| [r[time_k], r[column[:name]]] }} }, id: chart_id, min: nil %>
     <% elsif values.size == 3 && column_types == ["time", "string", "numeric"] %>
-      <%= line_chart @rows.group_by { |r| k = 1; v = r[k]; (@boom[k] || {})[v.to_s] || v }.map { |name, v| {name: name, data: v.map { |v2| [v2[0], v2[2]] } } }, id: chart_id, min: nil %>
+      <%= line_chart @rows.group_by { |r| k = @columns[1][:name]; v = r[k]; (@boom[k] || {})[v.to_s] || v }.map { |name, v| {name: name, data: v.map { |v2| [v2[@columns[0][:name]], v2[@columns[2][:name]]] } } }, id: chart_id, min: nil %>
     <% elsif values.size >= 2 && column_types == ["string"] + (values.size - 1).times.map { "numeric" } %>
-      <%= column_chart (values.size - 1).times.map { |i| name = @columns[i + 1][:name]; {name: name, data: @rows.first(20).map { |r| [(@boom[0] || {})[r[0].to_s] || r[0], r[i + 1]] } } }, id: chart_id %>
+      <%= column_chart (values.size - 1).times.map { |i| name = @columns[i + 1][:name]; {name: name, data: @rows.first(20).map { |r| [(@boom[@columns[0][:name]] || {})[r[@columns[0][:name]].to_s] || r[@columns[0][:name]], r[@columns[i + 1][:name]]] } } }, id: chart_id %>
     <% elsif @only_chart %>
       <% if @rows.size == 1 && @rows.first.size == 1 %>
         <p style="font-size: 160px;"><%= blazer_format_value(@columns.first[:name], @rows.first.values.first) %></p>

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -57,17 +57,15 @@
         map.fitBounds(featureLayer.getBounds());
       </script>
     <% elsif values.size >= 2 && column_types == ["time"] + (values.size - 1).times.map { "numeric" } %>
-      <% time_k = @columns.keys.first %>
-      <%= line_chart @columns.keys[1..-1].map{|k| {name: k, data: @rows.map{|r| [r[time_k], r[k]] }} }, id: chart_id, min: nil %>
+      <% time_k = @columns.first[:name] %>
+      <%= line_chart @columns[1..-1].map{|column| {name: column[:name], data: @rows.map{|r| [r[time_k], r[column[:name]]] }} }, id: chart_id, min: nil %>
     <% elsif values.size == 3 && column_types == ["time", "string", "numeric"] %>
-      <% keys = @columns.keys %>
-      <%= line_chart @rows.group_by { |r| k = keys[1]; v = r[k]; (@boom[k] || {})[v.to_s] || v }.map { |name, v| {name: name, data: v.map { |v2| [v2[keys[0]], v2[keys[2]]] } } }, id: chart_id, min: nil %>
+      <%= line_chart @rows.group_by { |r| k = 1; v = r[k]; (@boom[k] || {})[v.to_s] || v }.map { |name, v| {name: name, data: v.map { |v2| [v2[0], v2[2]] } } }, id: chart_id, min: nil %>
     <% elsif values.size >= 2 && column_types == ["string"] + (values.size - 1).times.map { "numeric" } %>
-      <% keys = @columns.keys %>
-      <%= column_chart (values.size - 1).times.map { |i| name = @columns.keys[i + 1]; {name: name, data: @rows.first(20).map { |r| [(@boom[keys[0]] || {})[r[keys[0]].to_s] || r[keys[0]], r[keys[i + 1]]] } } }, id: chart_id %>
+      <%= column_chart (values.size - 1).times.map { |i| name = @columns[i + 1][:name]; {name: name, data: @rows.first(20).map { |r| [(@boom[0] || {})[r[0].to_s] || r[0], r[i + 1]] } } }, id: chart_id %>
     <% elsif @only_chart %>
       <% if @rows.size == 1 && @rows.first.size == 1 %>
-        <p style="font-size: 160px;"><%= blazer_format_value(@rows.first.keys.first, @rows.first.values.first) %></p>
+        <p style="font-size: 160px;"><%= blazer_format_value(@columns.first[:name], @rows.first.values.first) %></p>
       <% else %>
         <% @no_chart = true %>
       <% end %>
@@ -79,10 +77,10 @@
         <table class="table results-table" style="margin-bottom: 0;">
           <thead>
             <tr>
-              <% @columns.each do |key, type| %>
-                <th style="width: <%= header_width %>%;" data-sort="<%= type %>">
-                  <div style="min-width: <%= @min_width_types.include?(key) ? 180 : 60 %>px;">
-                    <%= key %>
+              <% @columns.each do |column| %>
+                <th style="width: <%= header_width %>%;" data-sort="<%= column[:type] %>">
+                  <div style="min-width: <%= @min_width_types.include?(column[:orig_name]) ? 180 : 60 %>px;">
+                    <%= column[:name] %>
                   </div>
                 </th>
               <% end %>
@@ -91,7 +89,8 @@
           <tbody>
             <% @rows.each do |row| %>
               <tr>
-                <% row.each do |k, v| %>
+                <% @columns.each do |column| %>
+                  <% v = row[column[:name]] %>
                   <td>
                     <% if v.is_a?(Time) %>
                       <% v = v.in_time_zone(Blazer.time_zone) %>
@@ -100,13 +99,13 @@
                     <% unless v.nil? %>
                       <% if v == "" %>
                         <div class="text-muted">empty string</div>
-                      <% elsif @linked_columns[k] %>
-                        <%= link_to blazer_format_value(k, v), @linked_columns[k].gsub("{value}", u(v.to_s)), target: "_blank" %>
+                      <% elsif @linked_columns[column[:orig_name]] %>
+                        <%= link_to blazer_format_value(column[:orig_name], v), @linked_columns[column[:orig_name]].gsub("{value}", u(v.to_s)), target: "_blank" %>
                       <% else %>
-                        <%= blazer_format_value(k, v) %>
+                        <%= blazer_format_value(column[:orig_name], v) %>
                       <% end %>
 
-                      <% if v2 = (@boom[k] || {})[v.to_s] %>
+                      <% if v2 = (@boom[column[:name]] || {})[v.to_s] %>
                         <div class="text-muted"><%= v2 %></div>
                       <% end %>
                     <% end %>

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -54,7 +54,7 @@ module Blazer
       tries = 0
       # try 3 times on timeout errors
       begin
-        rows, error, cached_at = data_sources[check.query.data_source].run_statement(check.query.statement, refresh_cache: true)
+        columns, rows, error, cached_at = data_sources[check.query.data_source].run_statement(check.query.statement, refresh_cache: true)
         tries += 1
       end while error && error.include?("canceling statement due to statement timeout") && tries < 3
       check.update_state(rows, error)

--- a/lib/blazer/data_source.rb
+++ b/lib/blazer/data_source.rb
@@ -51,10 +51,10 @@ module Blazer
       cache_key = self.cache_key(statement) if cache
       if cache && !options[:refresh_cache]
         value = Blazer.cache.read(cache_key)
-        rows, cached_at = Marshal.load(value) if value
+        columns, rows, cached_at = Marshal.load(value) if value
       end
 
-      unless rows
+      unless rows && columns
         rows = []
         columns = []
 
@@ -107,7 +107,7 @@ module Blazer
           end
         end
 
-        Blazer.cache.write(cache_key, Marshal.dump([rows, Time.now]), expires_in: cache.to_f * 60) if !error && cache
+        Blazer.cache.write(cache_key, Marshal.dump([columns, rows, Time.now]), expires_in: cache.to_f * 60) if !error && cache
       end
 
       [columns, rows, error, cached_at]
@@ -118,7 +118,7 @@ module Blazer
     end
 
     def cache_key(statement)
-      ["blazer", "v2", id, Digest::MD5.hexdigest(statement)].join("/")
+      ["blazer", "v3", id, Digest::MD5.hexdigest(statement)].join("/")
     end
 
     def schemas

--- a/lib/blazer/data_source.rb
+++ b/lib/blazer/data_source.rb
@@ -56,6 +56,7 @@ module Blazer
 
       unless rows
         rows = []
+        columns = []
 
         comment = "blazer"
         if options[:user].respond_to?(:id)
@@ -73,10 +74,31 @@ module Blazer
           begin
             connection_model.connection.execute("SET statement_timeout = #{timeout.to_i * 1000}") if timeout && (postgresql? || redshift?)
             result = connection_model.connection.select_all("#{statement} /*#{comment}*/")
-            result.each do |untyped_row|
+            column_hash = {}
+            dupe_columns = []
+            result.columns.each_with_index do |column, col_number|
+              orig_name = column
+              uniq_col_idx = 1
+              while column_hash[column].present?
+                uniq_col_idx += 1
+                column = "#{orig_name}_#{uniq_col_idx}"
+                dupe_columns << orig_name
+              end
+              column_hash[column] = {name: column, orig_name: orig_name, col_number: col_number}
+            end
+
+            # Append a "_1" to the first of every duplicate set
+            dupe_columns.uniq.each do |column|
+              column_hash["#{column}_1"] = column_hash.delete(column).merge({name: "#{column}_1"})
+            end
+
+            columns = column_hash.values.sort_by { |column| column[:col_number] }
+
+            result.rows.each do |untyped_row|
               row = {}
-              untyped_row.each do |k, v|
-                row[k] = result.column_types.empty? ? v : result.column_types[k].send(:type_cast, v)
+              columns.each do |column|
+                value = untyped_row[column[:col_number]]
+                row[column[:name]] = result.column_types.empty? ? value : result.column_types[column[:orig_name]].send(:type_cast, value)
               end
               rows << row
             end
@@ -88,7 +110,7 @@ module Blazer
         Blazer.cache.write(cache_key, Marshal.dump([rows, Time.now]), expires_in: cache.to_f * 60) if !error && cache
       end
 
-      [rows, error, cached_at]
+      [columns, rows, error, cached_at]
     end
 
     def clear_cache(statement)
@@ -105,7 +127,7 @@ module Blazer
     end
 
     def tables
-      rows, error, cached_at = run_statement(connection_model.send(:sanitize_sql_array, ["SELECT table_name, column_name, ordinal_position, data_type FROM information_schema.columns WHERE table_schema IN (?)", schemas]))
+      columns, rows, error, cached_at = run_statement(connection_model.send(:sanitize_sql_array, ["SELECT table_name, column_name, ordinal_position, data_type FROM information_schema.columns WHERE table_schema IN (?)", schemas]))
       Hash[rows.group_by { |r| r["table_name"] }.map { |t, f| [t, f.sort_by { |f| f["ordinal_position"] }.map { |f| f.slice("column_name", "data_type") }] }.sort_by { |t, _f| t }]
     end
 


### PR DESCRIPTION
Consider this query: 
```sql
select 
   city.id, city.name, country.id, country.name 
from 
   city 
   inner join country on city.country_id = country.id
```

Previously, Blazer would only display two columns: `id, name`

With this change, the same query will now return: `id_1, name_1, id_2,
name_2`

smart_columns and linked_columns will continue to work, as the original column name is preserved for their use.