### PR TITLE
Adds optional before_action configuration for blazer controller authentication/authorization

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -9,8 +9,8 @@ module Blazer
       http_basic_authenticate_with name: ENV["BLAZER_USERNAME"], password: ENV["BLAZER_PASSWORD"]
     end
 
-    if Blazer.auth_filter
-      before_action Blazer.auth_filter
+    if Blazer.before_filter
+      before_action Blazer.before_filter
     end
 
     layout "blazer/application"

--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -9,6 +9,10 @@ module Blazer
       http_basic_authenticate_with name: ENV["BLAZER_USERNAME"], password: ENV["BLAZER_PASSWORD"]
     end
 
+    if Blazer.auth_filter
+      before_action Blazer.auth_filter
+    end
+
     layout "blazer/application"
 
     before_action :ensure_database_url

--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -9,8 +9,8 @@ module Blazer
       http_basic_authenticate_with name: ENV["BLAZER_USERNAME"], password: ENV["BLAZER_PASSWORD"]
     end
 
-    if Blazer.before_filter
-      before_action Blazer.before_filter
+    if Blazer.before_action
+      before_action Blazer.before_action
     end
 
     layout "blazer/application"

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -13,7 +13,7 @@ module Blazer
     attr_accessor :user_name
     attr_accessor :user_class
     attr_accessor :user_method
-    attr_accessor :auth_filter
+    attr_accessor :before_filter
     attr_accessor :from_email
     attr_accessor :cache
     attr_accessor :transform_statement

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -13,6 +13,7 @@ module Blazer
     attr_accessor :user_name
     attr_accessor :user_class
     attr_accessor :user_method
+    attr_accessor :auth_filter
     attr_accessor :from_email
     attr_accessor :cache
     attr_accessor :transform_statement

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -13,7 +13,7 @@ module Blazer
     attr_accessor :user_name
     attr_accessor :user_class
     attr_accessor :user_method
-    attr_accessor :before_filter
+    attr_accessor :before_action
     attr_accessor :from_email
     attr_accessor :cache
     attr_accessor :transform_statement

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -11,7 +11,7 @@ module Blazer
       Blazer.audit = Blazer.settings.key?("audit") ? Blazer.settings["audit"] : true
       Blazer.user_name = Blazer.settings["user_name"] if Blazer.settings["user_name"]
       Blazer.from_email = Blazer.settings["from_email"] if Blazer.settings["from_email"]
-      Blazer.before_filter = Blazer.settings["before_filter"] if Blazer.settings["before_filter"]
+      Blazer.before_action = Blazer.settings["before_action"] if Blazer.settings["before_action"]
 
       Blazer.user_class ||= Blazer.settings.key?("user_class") ? Blazer.settings["user_class"] : (User rescue nil)
       Blazer.user_method = Blazer.settings["user_method"]

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -11,6 +11,7 @@ module Blazer
       Blazer.audit = Blazer.settings.key?("audit") ? Blazer.settings["audit"] : true
       Blazer.user_name = Blazer.settings["user_name"] if Blazer.settings["user_name"]
       Blazer.from_email = Blazer.settings["from_email"] if Blazer.settings["from_email"]
+      Blazer.auth_filter = Blazer.settings["auth_filter"] if Blazer.settings["auth_filter"]
 
       Blazer.user_class ||= Blazer.settings.key?("user_class") ? Blazer.settings["user_class"] : (User rescue nil)
       Blazer.user_method = Blazer.settings["user_method"]

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -11,7 +11,7 @@ module Blazer
       Blazer.audit = Blazer.settings.key?("audit") ? Blazer.settings["audit"] : true
       Blazer.user_name = Blazer.settings["user_name"] if Blazer.settings["user_name"]
       Blazer.from_email = Blazer.settings["from_email"] if Blazer.settings["from_email"]
-      Blazer.auth_filter = Blazer.settings["auth_filter"] if Blazer.settings["auth_filter"]
+      Blazer.before_filter = Blazer.settings["before_filter"] if Blazer.settings["before_filter"]
 
       Blazer.user_class ||= Blazer.settings.key?("user_class") ? Blazer.settings["user_class"] : (User rescue nil)
       Blazer.user_method = Blazer.settings["user_method"]

--- a/lib/generators/blazer/templates/config.yml
+++ b/lib/generators/blazer/templates/config.yml
@@ -41,7 +41,7 @@ audit: true
 # user_name: name
 
 # optional auth method to use as a before_action (default: nil)
-# auth_filter: :authenticate!
+# before_filter: :authenticate!
 
 # email to send checks from
 # from_email: blazer@example.org

--- a/lib/generators/blazer/templates/config.yml
+++ b/lib/generators/blazer/templates/config.yml
@@ -40,5 +40,8 @@ audit: true
 # method name for the user model
 # user_name: name
 
+# optional auth method to use as a before_action (default: nil)
+# auth_filter: :authenticate!
+
 # email to send checks from
 # from_email: blazer@example.org

--- a/lib/generators/blazer/templates/config.yml
+++ b/lib/generators/blazer/templates/config.yml
@@ -41,7 +41,7 @@ audit: true
 # user_name: name
 
 # optional auth method to use as a before_action (default: nil)
-# before_filter: :authenticate!
+# before_action: :authenticate!
 
 # email to send checks from
 # from_email: blazer@example.org


### PR DESCRIPTION
Older versions of devise + rails don't allow use of the `authenticate` method in your `config/routes.rb`, which means the only option for auth in blazer under that setup is http basic auth.

This adds support for an optional `before_action` configuration which allows specifying a method name as a symbol. That method will then be called as a `before_action` in the `Blazer::BaseController` so you can plug in your own auth flow (such as calling devise's `authenticate!`) or really do whatever you want.