### PR TITLE
fix statement issue (414 Request-URI Too Large) for long sql statement at Download button

### DIFF
--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -28,7 +28,7 @@
         <%= link_to "Fork", new_query_path(variable_params.merge(statement: @query.statement, data_source: @query.data_source, name: "Fork of #{@query.name}")), class: "btn btn-info" %>
 
         <% if !@error && @success %>
-          <%= button_to "Download", run_queries_path(statement: @statement, query_id: @query.id, format: "csv"), class: "btn btn-primary" %>
+          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv"), params: {statement: @statement}, class: "btn btn-primary" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
SQL string in @statement can be very large to pass into a URL. Request URI is limited in about 8KB which depends on server configuration or browser. When statement size exceeds the limit, it will cause the error 414 Request-URI Too large.   So I think it should be passed as a body param.