### PR TITLE
Corrected typo in migration in install.rb

### DIFF
--- a/lib/generators/blazer/templates/install.rb
+++ b/lib/generators/blazer/templates/install.rb
@@ -18,7 +18,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     end
 
     create_table :blazer_dashboards do |t|
-      t.refrences :creator
+      t.references :creator
       t.text :name
       t.timestamps
     end


### PR DESCRIPTION
A small typo which prevented correct migration: refrences -> references