### PR TITLE
Add the ability to only query selected SQL

### DIFF
--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -103,6 +103,12 @@
     editor.resize();
   };
 
+  function getSQL() {
+    var selectedText = editor.getSelectedText();
+    var text = selectedText.length == 0 ? editor.getValue() : selectedText;
+    return text.replace(/\n/g, "\r\n");
+  }
+
   editor.getSession().on("change", adjustHeight);
   adjustHeight();
   $("#editor").show();
@@ -125,7 +131,7 @@
       xhr.abort();
     }
 
-    var data = $.extend({}, params, {statement: editor.getValue().replace(/\n/g, "\r\n"), data_source: $("#query_data_source").val()});
+    var data = $.extend({}, params, {statement: getSQL(), data_source: $("#query_data_source").val()});
 
     xhr = runQuery(data, function (data) {
       $("#results").html(data);


### PR DESCRIPTION
Many times I saw people comment/uncomment different queries in a same window for testing, this could make their (including me) life easier :)

What it does:
1. if user haven't selected any text, it works exactly as before
2. if user select one or two lines SQL, it only run that part

<img width="1173" alt="screenshot 2016-06-17 20 54 55" src="https://cloud.githubusercontent.com/assets/128977/16168931/460d2d7a-34cf-11e6-848c-0353bc84438e.png">
