### PR TITLE
Render images for columns that end in 'image'

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -37,6 +37,10 @@ module Blazer
       ENV["MAPBOX_ACCESS_TOKEN"].present?
     end
 
+    def blazer_image?(key, value)
+      key.to_s.end_with?("image") && value.is_a?(String) && %w[png jpg jpeg].include?(value.split(".").last)
+    end
+
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
     JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 

--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -38,7 +38,7 @@ module Blazer
     end
 
     def blazer_image?(key, value)
-      key.to_s.end_with?("image") && value.is_a?(String) && %w[png jpg jpeg].include?(value.split(".").last)
+      key.to_s.end_with?("image") && value.is_a?(String) && %w[png jpg jpeg gif].include?(value.split(".").last.split("?").first)
     end
 
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -124,6 +124,10 @@
                           <div class="text-muted">empty string</div>
                         <% elsif @linked_columns[k] %>
                           <%= link_to blazer_format_value(k, v), @linked_columns[k].gsub("{value}", u(v.to_s)), target: "_blank" %>
+                        <% elsif blazer_image?(k, v) %>
+                          <%= link_to blazer_format_value(k, v), target: "_blank" do %>
+                            <%= image_tag blazer_format_value(k, v), width: '200px' %>
+                          <% end %>
                         <% else %>
                           <%= blazer_format_value(k, v) %>
                         <% end %>


### PR DESCRIPTION
Renders image URLs in query results and links to the image.

Example SQL:

```
SELECT 'http://www.github.com/image.jpg' AS github_image;
```

Blazer Output:

```
github_image
---
<a href="http://www.github.com/image.jpg" target="_blank"><img src="http://www.github.com/image.jpg" width="200"></a>
```

![image](https://cloud.githubusercontent.com/assets/227274/16320899/10f3f6a8-394f-11e6-93c5-fae3a8fc8c10.png)
