### PR TITLE
Fixbug: it shows incorrect error line num when we only query selected SQL

### DIFF
--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -106,6 +106,18 @@
     return text.replace(/\n/g, "\r\n");
   }
 
+  function getErrorLine() {
+    var error_line = /LINE (\d+)/g.exec($("#results").find('.alert-danger').text());
+
+    if (error_line) {
+      error_line = parseInt(error_line[1], 10);
+      if (editor.getSelectedText().length > 0) {
+        error_line += editor.getSelectionRange().start.row;
+      }
+      return error_line;
+    }
+  }
+
   editor.getSession().on("change", adjustHeight);
   adjustHeight();
   $("#editor").show();
@@ -133,10 +145,8 @@
     xhr = runQuery(data, function (data) {
       $("#results").html(data);
 
-      error_line = /LINE (\d+)/g.exec($("#results").find('.alert-danger').text());
-
+      error_line = getErrorLine();
       if (error_line) {
-        error_line = parseInt(error_line[1], 10);
         editor.getSession().addGutterDecoration(error_line - 1, "error");
         editor.scrollToLine(error_line, true, true, function () {});
         editor.gotoLine(error_line, 0, true);


### PR DESCRIPTION
How to reproduce:

1. write 2 queries and make sure the 2nd query has a syntax error
1. select the 2nd query and run it
1. then you will notice the error line is incorrect, we should add a "padding" on it

Here is the before vs after, sorry for the issue I involved last time.
![pjimage](https://cloud.githubusercontent.com/assets/128977/16640541/a9b62aec-43ad-11e6-9b54-fd80817c3ca6.jpg)
