### PR TITLE
Remove `before_action :verify_request_size` from BaseController

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -6,7 +6,6 @@ module Blazer
       skip_before_action(*filters, raise: false)
       skip_after_action(*filters, raise: false)
       skip_around_action(*filters, raise: false)
-      before_action :verify_request_size
     else
       skip_action_callback *filters
     end


### PR DESCRIPTION
Best I can tell, this line was carried over from Ahoy by accident in commit 4e973845656a547c8330f336772f6be326e3a971. There is no `verify_request_size` method in Blazer, so this was raising an exception.