### PR TITLE
Day of week names

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,20 @@ smart_columns:
   city_id: "SELECT id, name FROM cities WHERE id IN {value}"
 ```
 
+You can also put a Hash into the config for more static data:
+
+```yml
+smart_columns:
+  day_of_week:
+    0: Sun
+    1: Mon
+    2: Tue
+    3: Wed
+    4: Thu
+    5: Fri
+    6: Sat
+```
+
 ### Caching
 
 Blazer can automatically cache results to improve speed. It can cache slow queries:

--- a/README.md
+++ b/README.md
@@ -220,18 +220,17 @@ smart_columns:
   city_id: "SELECT id, name FROM cities WHERE id IN {value}"
 ```
 
-You can also put a Hash into the config for more static data:
+You can also put a Hash into the config for static data:
 
 ```yml
 smart_columns:
-  day_of_week:
-    0: Sun
-    1: Mon
-    2: Tue
-    3: Wed
-    4: Thu
-    5: Fri
-    6: Sat
+  gender: {M: Male, F: Female}
+```
+
+Or an array for numeric index based lookups:
+```yml
+smart_columns:
+  day_of_week: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 ```
 
 ### Caching

--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -12,9 +12,7 @@ module Blazer
     BLAZER_IMAGE_EXT = %w[png jpg jpeg gif]
 
     def blazer_format_value(key, value)
-      if key == "day_of_week" && value.is_a?(Integer) && defined?(I18n)
-        I18n.t("date.day_names")[value] || value
-      elsif value.is_a?(Integer) && !key.to_s.end_with?("id") && !key.to_s.start_with?("id")
+      if value.is_a?(Integer) && !key.to_s.end_with?("id") && !key.to_s.start_with?("id")
         number_with_delimiter(value)
       elsif value =~ BLAZER_URL_REGEX
         # see if image or link

--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -12,7 +12,9 @@ module Blazer
     BLAZER_IMAGE_EXT = %w[png jpg jpeg gif]
 
     def blazer_format_value(key, value)
-      if value.is_a?(Integer) && !key.to_s.end_with?("id") && !key.to_s.start_with?("id")
+      if key == "day_of_week" && value.is_a?(Integer) && defined?(I18n)
+        I18n.t("date.day_names")[value] || value
+      elsif value.is_a?(Integer) && !key.to_s.end_with?("id") && !key.to_s.start_with?("id")
         number_with_delimiter(value)
       elsif value =~ BLAZER_URL_REGEX
         # see if image or link

--- a/lib/blazer/result.rb
+++ b/lib/blazer/result.rb
@@ -30,6 +30,8 @@ module Blazer
             values = rows.map { |r| r[i] }.compact.uniq
             result = data_source.run_statement(ActiveRecord::Base.send(:sanitize_sql_array, [query.sub("{value}", "(?)"), values]))
             boom[key] = Hash[result.rows.map { |k, v| [k.to_s, v] }]
+          elsif key == "day_of_week" && defined?(I18n)
+            boom[key] = I18n.t("date.day_names")
           end
         end
         boom

--- a/lib/blazer/result.rb
+++ b/lib/blazer/result.rb
@@ -24,7 +24,9 @@ module Blazer
         boom = {}
         columns.each_with_index do |key, i|
           query = data_source.smart_columns[key]
-          if query
+          if query && query.is_a?(Hash)
+            boom[key] = query.transform_keys(&:to_s)
+          elsif query
             values = rows.map { |r| r[i] }.compact.uniq
             result = data_source.run_statement(ActiveRecord::Base.send(:sanitize_sql_array, [query.sub("{value}", "(?)"), values]))
             boom[key] = Hash[result.rows.map { |k, v| [k.to_s, v] }]

--- a/lib/blazer/result.rb
+++ b/lib/blazer/result.rb
@@ -25,13 +25,13 @@ module Blazer
         columns.each_with_index do |key, i|
           query = data_source.smart_columns[key]
           if query && query.is_a?(Hash)
-            boom[key] = query.transform_keys(&:to_s)
+            boom[key] = query.stringify_keys
+          elsif query && query.is_a?(Array)
+            boom[key] = Hash[(0..query.size-1).zip(query)].transform_keys(&:to_s)
           elsif query
             values = rows.map { |r| r[i] }.compact.uniq
             result = data_source.run_statement(ActiveRecord::Base.send(:sanitize_sql_array, [query.sub("{value}", "(?)"), values]))
             boom[key] = Hash[result.rows.map { |k, v| [k.to_s, v] }]
-          elsif key == "day_of_week" && defined?(I18n)
-            boom[key] = I18n.t("date.day_names")
           end
         end
         boom

--- a/lib/generators/blazer/templates/config.yml
+++ b/lib/generators/blazer/templates/config.yml
@@ -29,6 +29,8 @@ data_sources:
 
     smart_columns:
       # user_id: "SELECT id, name FROM users WHERE id IN {value}"
+      # gender: {M: Male, F: Female}
+      # day_of_week: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 # create audits
 audit: true


### PR DESCRIPTION
Not sure of your opinion here. We have a lot of weekday stats but the `gd_day_of_week` sql function returns an int so that needs to be converted in order to end up in charts and easily readable datatable. Figured the hash style `smart_columns` mapping could be useful for other purposes/non-db enums while falling back to the I18n implementation for `day_of_week` named columns.

If you'd like only go with one of the approaches or perhaps not even I18n just `Date::DAY_NAMES` I'm open to suggestions
