### PR TITLE
Allow downloading csv via GET request

### DIFF
--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -14,7 +14,7 @@
         <%= link_to "Fork", new_query_path(variable_params.merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
 
         <% if !@error && @success %>
-          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv"), params: {statement: @statement}, class: "btn btn-primary" %>
+          <%= link_to "Download", run_queries_path(query_id: @query.id, format: "csv", params: {statement: @statement}), class: "btn btn-primary" %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Blazer::Engine.routes.draw do
   resources :queries do
     post :run, on: :collection # err on the side of caution
+    get :run, on: :collection
     post :refresh, on: :member
     get :tables, on: :collection
   end


### PR DESCRIPTION
When using our BI system with R, it'd be really nice if we could expose the CSV downloads to a GET request, so all we have to do is call `read.csv('http://user:pass@example.com/queries/run.csv?...')` to get at the data.

This is obviously a little awkward the way that this is set up, so I'm opening the PR to start the conversation. I don't want the raw SQL query to be in my link, I want the query to be constructed from parameters the same way it is on `queries#show`. In fact, would it make sense for `queries#show.csv` to return the CSV results of the run?