### PR TITLE
Make things more mobile responsive

### DIFF
--- a/app/assets/stylesheets/blazer/application.css
+++ b/app/assets/stylesheets/blazer/application.css
@@ -188,3 +188,32 @@ input.search:focus {
   overflow-x: auto;
   overflow-y: hidden;
 }
+
+.btn-query {
+  vertical-align: top;
+  width: 70px;
+}
+
+.selectize-schemas-wrapper {
+  display: inline;
+}
+
+@media screen and (min-width: 768px) and (max-width: 991px) {
+  .query-actions .btn-link {
+    padding: 2px;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  .btn-query {
+    width: 100%;
+  }
+  .selectize-schemas-wrapper {
+    text-align: center;
+    display: block;
+  }
+
+  .query-actions {
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/blazer/application.css
+++ b/app/assets/stylesheets/blazer/application.css
@@ -12,8 +12,11 @@ pre {
 }
 
 body {
-  padding-top: 20px;
   padding-bottom: 20px;
+}
+
+body.no-topbar {
+  padding-top: 20px;
 }
 
 .results-table th {
@@ -139,13 +142,14 @@ input.search:focus {
 }
 
 .topbar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
   background-color: whitesmoke;
-  height: 60px;
   z-index: 1001;
+  padding: 10px 0;
+  margin-bottom: 10px;
+}
+
+.topbar.topbar-transparent {
+  background-color: transparent;
 }
 
 .glyphicon-remove {
@@ -173,4 +177,14 @@ input.search:focus {
 
 #code.expanded {
   max-height: none;
+}
+
+.blazer-nav {
+  vertical-align: top;
+  margin-right: 5px;
+}
+
+.table-responsive {
+  overflow-x: auto;
+  overflow-y: hidden;
 }

--- a/app/views/blazer/_nav.html.erb
+++ b/app/views/blazer/_nav.html.erb
@@ -1,4 +1,4 @@
-<div class="btn-group" style="vertical-align: top; margin-right: 5px;">
+<div class="btn-group blazer-nav">
   <%= link_to "Home", root_path, class: "btn btn-primary" %>
   <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <span class="caret"></span>

--- a/app/views/blazer/checks/index.html.erb
+++ b/app/views/blazer/checks/index.html.erb
@@ -1,40 +1,50 @@
 <% blazer_title "Checks" %>
 
-<p style="float: right;"><%= link_to "New Check", new_check_path, class: "btn btn-info" %></p>
-<%= render partial: "blazer/nav" %>
+<% content_for :topbar do %>
+  <div class="topbar topbar-transparent">
+    <div class="container">
+      <div class="pull-right">
+        <%= render partial: "blazer/nav" %>
+        <%= link_to "New Check", new_check_path, class: "btn btn-info" %>
+      </div>
+    </div>
+  </div>
+<% end %>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Query</th>
-      <th style="width: 10%;">State</th>
-      <th style="width: 10%;">Run</th>
-      <th style="width: 20%;">Emails</th>
-      <th style="width: 15%;"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @checks.each do |check| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= link_to check.query.name, check.query %> <span class="text-muted"><%= check.try(:check_type).to_s.gsub("_", " ") %></span></td>
-        <td>
-          <% if check.state %>
-            <small class="check-state <%= check.state.parameterize("_") %>"><%= check.state.upcase %></small>
-          <% end %>
-        </td>
-        <td><%= check.schedule if check.respond_to?(:schedule) %></td>
-        <td>
-          <ul class="list-unstyled" style="margin-bottom: 0;">
-            <% check.split_emails.each do |email| %>
-              <li><%= email %></li>
-            <% end %>
-          </ul>
-        </td>
-        <td style="text-align: right; padding: 1px;">
-          <%= link_to "Edit", edit_check_path(check), class: "btn btn-info" %>
-          <%= link_to "Run Now", query_path(check.query), class: "btn btn-primary" %>
-        </td>
+        <th>Query</th>
+        <th style="width: 10%;">State</th>
+        <th style="width: 10%;">Run</th>
+        <th style="width: 20%;">Emails</th>
+        <th style="width: 15%;"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @checks.each do |check| %>
+        <tr>
+          <td><%= link_to check.query.name, check.query %> <span class="text-muted"><%= check.try(:check_type).to_s.gsub("_", " ") %></span></td>
+          <td>
+            <% if check.state %>
+              <small class="check-state <%= check.state.parameterize("_") %>"><%= check.state.upcase %></small>
+            <% end %>
+          </td>
+          <td><%= check.schedule if check.respond_to?(:schedule) %></td>
+          <td>
+            <ul class="list-unstyled" style="margin-bottom: 0;">
+              <% check.split_emails.each do |email| %>
+                <li><%= email %></li>
+              <% end %>
+            </ul>
+          </td>
+          <td style="text-align: right; padding: 1px;">
+            <%= link_to "Edit", edit_check_path(check), class: "btn btn-info" %>
+            <%= link_to "Run Now", query_path(check.query), class: "btn btn-primary" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/blazer/dashboards/_form.html.erb
+++ b/app/views/blazer/dashboards/_form.html.erb
@@ -12,7 +12,7 @@
     <ul class="list-group">
       <% (@queries || @dashboard.dashboard_queries.order(:position).map(&:query)).each do |query| %>
         <li class="list-group-item">
-          <span class="glyphicon glyphicon-remove" aria-hidden="true" style="float: right; margin-top: 3px;"></span>
+          <span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" style="margin-top: 3px;"></span>
           <%= query.name %>
           <%= hidden_field_tag "query_ids[]", query.id %>
         </li>
@@ -33,7 +33,7 @@
           var $li = $("<li></li>");
           $li.addClass("list-group-item");
           $li.text($option.text());
-          $li.prepend('<span class="glyphicon glyphicon-remove" aria-hidden="true" style="float: right; margin-top: 3px;"></span><input type="hidden" name="query_ids[]" id="query_ids_" value="' + $option.val() + '">');
+          $li.prepend('<span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" style="margin-top: 3px;"></span><input type="hidden" name="query_ids[]" id="query_ids_" value="' + $option.val() + '">');
           $(".list-group").append($li);
           $(this)[0].selectize.setValue("");
           $(".form-group").removeClass("hide");

--- a/app/views/blazer/dashboards/index.html.erb
+++ b/app/views/blazer/dashboards/index.html.erb
@@ -1,19 +1,29 @@
 <% blazer_title "Dashboards" %>
 
-<p style="float: right;"><%= link_to "New Dashboard", new_dashboard_path, class: "btn btn-info" %></p>
-<%= render partial: "blazer/nav" %>
+<% content_for :topbar do %>
+  <div class="topbar topbar-transparent">
+    <div class="container">
+      <div class="pull-right">
+        <%= render partial: "blazer/nav" %>
+        <%= link_to "New Dashboard", new_dashboard_path, class: "btn btn-info" %>
+      </div>
+    </div>
+  </div>
+<% end %>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Dashboard</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @dashboards.each do |dashboard| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= link_to dashboard.name, dashboard %></td>
+        <th>Dashboard</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @dashboards.each do |dashboard| %>
+        <tr>
+          <td><%= link_to dashboard.name, dashboard %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/blazer/dashboards/show.html.erb
+++ b/app/views/blazer/dashboards/show.html.erb
@@ -1,25 +1,25 @@
 <% blazer_title @dashboard.name %>
 
-<div class="topbar">
-  <div class="container">
-    <div class="row" style="padding-top: 13px;">
-      <div class="col-sm-9">
-        <%= render partial: "blazer/nav" %>
-        <h3 style="margin: 0; line-height: 34px; display: inline;">
-          <%= @dashboard.name %>
-        </h3>
-      </div>
-      <div class="col-sm-3 text-right">
-        <%= link_to "Edit", edit_dashboard_path(@dashboard, variable_params), class: "btn btn-info" %>
+<% content_for :topbar do %>
+  <div class="topbar">
+    <div class="container">
+      <div class="row" style="padding-top: 13px;">
+        <div class="col-sm-6 col-xs-12">
+          <h3 style="margin: 0; line-height: 34px; display: inline;">
+            <%= @dashboard.name %>
+          </h3>
+        </div>
+        <div class="col-sm-6 col-xs-12 text-right">
+          <%= render partial: "blazer/nav" %>
+          <%= link_to "Edit", edit_dashboard_path(@dashboard, variable_params), class: "btn btn-info" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
-
-<div style="margin-bottom: 60px;"></div>
+<% end %>
 
 <% if @data_sources.any? { |ds| ds.cache_mode != "off" } %>
-  <p class="text-muted" style="float: right;">
+  <p class="text-muted pull-right">
     Some queries may be cached
     <%= link_to "Refresh", refresh_dashboard_path(@dashboard, variable_params), method: :post %>
   </p>

--- a/app/views/blazer/dashboards/show.html.erb
+++ b/app/views/blazer/dashboards/show.html.erb
@@ -29,7 +29,7 @@
 
 <% @queries.each_with_index do |query, i| %>
   <div style="padding-top: 10px; clear: both;">
-    <h4 style="text-align: center;"><%= link_to query.friendly_name, query_path(query, variable_params), target: "_blank", style: "color: inherit;" %></h4>
+    <h4 class="text-center"><%= link_to query.friendly_name, query_path(query, variable_params), target: "_blank", style: "color: inherit;" %></h4>
     <div id="chart-<%= i %>" class="chart">
       <p class="text-muted">Loading...</p>
     </div>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -4,31 +4,31 @@
 
 <%= form_for @query, url: (@query.persisted? ? query_path(@query, variable_params) : queries_path(variable_params)), html: {class: "the_form", autocomplete: "off"} do |f| %>
   <div class="row">
-    <div id="statement-box" class="col-xs-8">
+    <div id="statement-box" class="col-sm-8">
       <div class= "form-group">
         <%= f.hidden_field :statement %>
         <div id="editor-container">
           <div id="editor"><%= @query.statement %></div>
         </div>
       </div>
-      <div class="form-group text-right">
-        <div class="pull-left" style="margin-top: 9px;">
-          <%= link_to "Back", :back %>
+      <div class="form-group query-actions text-right">
+        <%= link_to "Back", :back, class: 'btn btn-link' %>
+        <%= link_to "Schema", "#", target: "_blank", id: "view-schema", class: 'btn btn-link' %>
+        <div class="selectize-schemas-wrapper">
+          <%= f.select :data_source, Blazer.data_sources.values.map { |ds| [ds.name, ds.id] }, {}, class: ("hide" if Blazer.data_sources.size == 1), style: "width: 140px;" %>
+          <div id="tables" style="display: inline-block; width: 250px; margin-right: 10px;" class="hide">
+            <%= render partial: "tables" %>
+          </div>
+          <script>
+            updatePreviewSelect();
+            $("#query_data_source").selectize().change(updatePreviewSelect);
+          </script>
         </div>
-        <%= link_to "Schema", "#", target: "_blank", id: "view-schema", style: "margin-right: 10px;" %>
-        <%= f.select :data_source, Blazer.data_sources.values.map { |ds| [ds.name, ds.id] }, {}, class: ("hide" if Blazer.data_sources.size == 1), style: "width: 140px;" %>
-        <div id="tables" style="display: inline-block; width: 250px; margin-right: 10px;" class="hide">
-          <%= render partial: "tables" %>
-        </div>
-        <script>
-          updatePreviewSelect();
-          $("#query_data_source").selectize().change(updatePreviewSelect);
-        </script>
-        <%= link_to "Run", "#", class: "btn btn-info", id: "run", style: "vertical-align: top; width: 70px;" %>
-        <%= link_to "Cancel", "#", class: "btn btn-danger hide", id: "cancel", style: "vertical-align: top; width: 70px;" %>
+        <%= link_to "Run", "#", class: "btn btn-info btn-query", id: "run" %>
+        <%= link_to "Cancel", "#", class: "btn btn-danger btn-query hide", id: "cancel" %>
       </div>
     </div>
-    <div class="col-xs-4">
+    <div class="col-sm-4">
       <div class="form-group">
         <%= f.label :name %>
         <%= f.text_field :name, class: "form-control" %>

--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -1,51 +1,57 @@
-<div id="queries">
-  <div id="header" style="margin-bottom: 20px;">
-    <div class="pull-right">
-      <% if blazer_user %>
-        <%= link_to "All", root_path, class: !params[:filter] ? "active" : nil, style: "margin-right: 40px;" %>
+<% content_for :topbar do %>
+  <div class="topbar topbar-transparent">
+    <div class="container">
+      <div class="pull-right">
+        <% if blazer_user %>
+          <%= link_to "All", root_path, class: !params[:filter] ? "active" : nil, style: "margin-right: 40px;" %>
 
-        <% if Blazer.audit %>
-          <%= link_to "Viewed", root_path(filter: "viewed"), class: params[:filter] == "viewed" ? "active" : nil, style: "margin-right: 40px;" %>
+          <% if Blazer.audit %>
+            <%= link_to "Viewed", root_path(filter: "viewed"), class: params[:filter] == "viewed" ? "active" : nil, style: "margin-right: 40px;" %>
+          <% end %>
+
+          <%= link_to "Mine", root_path(filter: "mine"), class: params[:filter] == "mine" ? "active" : nil, style: "margin-right: 40px;" %>
         <% end %>
-
-        <%= link_to "Mine", root_path(filter: "mine"), class: params[:filter] == "mine" ? "active" : nil, style: "margin-right: 40px;" %>
-      <% end %>
-      <div class="btn-group">
-        <%= link_to "New Query", new_query_path, class: "btn btn-info" %>
-        <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <span class="caret"></span>
-          <span class="sr-only">Toggle Dropdown</span>
-        </button>
-        <ul class="dropdown-menu">
-          <li><%= link_to "Dashboards", dashboards_path %></li>
-          <li><%= link_to "Checks", checks_path %></li>
-          <li role="separator" class="divider"></li>
-          <li><%= link_to "New Dashboard", new_dashboard_path %></li>
-          <li><%= link_to "New Check", new_check_path %></li>
-        </ul>
+        <div class="btn-group">
+          <%= link_to "New Query", new_query_path, class: "btn btn-info" %>
+          <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="caret"></span>
+            <span class="sr-only">Toggle Dropdown</span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><%= link_to "Dashboards", dashboards_path %></li>
+            <li><%= link_to "Checks", checks_path %></li>
+            <li role="separator" class="divider"></li>
+            <li><%= link_to "New Dashboard", new_dashboard_path %></li>
+            <li><%= link_to "New Check", new_check_path %></li>
+          </ul>
+        </div>
       </div>
+      <input type="text" placeholder="Start typing a query or person" style="width: 300px; display: inline-block;" autofocus=true class="search form-control" />
     </div>
-    <input type="text" placeholder="Start typing a query or person" style="width: 300px; display: inline-block;" autofocus=true class="search form-control" />
   </div>
+<% end %>
 
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th style="width: 20%; text-align: right;">Mastermind</th>
-      </tr>
-    </thead>
-    <tbody class="list">
-      <tr id="search-item">
-        <td>
-          <span class="name"></span>
-          <span class="vars"></span>
-          <span class="hide"></span>
-        </td>
-        <td class="creator"></td>
-      </tr>
-    </tbody>
-  </table>
+<div id="queries">
+  <div class="table-responsive">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th style="width: 20%; text-align: right;">Mastermind</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <tr id="search-item">
+          <td>
+            <span class="name"></span>
+            <span class="vars"></span>
+            <span class="hide"></span>
+          </td>
+          <td class="creator"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <script>

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -9,7 +9,7 @@
 <% else %>
   <% unless @only_chart %>
     <% if @cached_at || @just_cached %>
-      <p class="text-muted" style="float: right;">
+      <p class="text-muted pull-right">
         <% if @cached_at %>
           Cached <%= time_ago_in_words(@cached_at, include_seconds: true) %> ago
         <% elsif !params[:data_source] %>
@@ -110,48 +110,50 @@
         <% if @columns == ["QUERY PLAN"] %>
           <pre><code><%= @rows.map { |r| r[0] }.join("\n") %></code></pre>
         <% else %>
-          <table class="table results-table" style="margin-bottom: 0;">
-            <thead>
-              <tr>
-                <% @columns.each_with_index do |key, i| %>
-                  <% type = @column_types[i] %>
-                  <th style="width: <%= header_width %>%;" data-sort="<%= type %>">
-                    <div style="min-width: <%= @min_width_types.include?(i) ? 180 : 60 %>px;">
-                      <%= key %>
-                    </div>
-                  </th>
-                <% end %>
-              </tr>
-            </thead>
-            <tbody>
-              <% @rows.each do |row| %>
+          <div class="table-responsive">
+            <table class="table results-table" style="margin-bottom: 0;">
+              <thead>
                 <tr>
-                  <% row.each_with_index do |v, i| %>
-                    <% k = @columns[i] %>
-                    <td>
-                      <% if v.is_a?(Time) %>
-                        <% v = blazer_time_value(@data_source, k, v) %>
-                      <% end %>
-
-                      <% unless v.nil? %>
-                        <% if v.is_a?(String) && v == "" %>
-                          <div class="text-muted">empty string</div>
-                        <% elsif @linked_columns[k] %>
-                          <%= link_to blazer_format_value(k, v), @linked_columns[k].gsub("{value}", u(v.to_s)), target: "_blank" %>
-                        <% else %>
-                          <%= blazer_format_value(k, v) %>
-                        <% end %>
-
-                        <% if v2 = (@boom[k] || {})[v.to_s] %>
-                          <div class="text-muted"><%= v2 %></div>
-                        <% end %>
-                      <% end %>
-                    </td>
+                  <% @columns.each_with_index do |key, i| %>
+                    <% type = @column_types[i] %>
+                    <th style="width: <%= header_width %>%;" data-sort="<%= type %>">
+                      <div style="min-width: <%= @min_width_types.include?(i) ? 180 : 60 %>px;">
+                        <%= key %>
+                      </div>
+                    </th>
                   <% end %>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                <% @rows.each do |row| %>
+                  <tr>
+                    <% row.each_with_index do |v, i| %>
+                      <% k = @columns[i] %>
+                      <td>
+                        <% if v.is_a?(Time) %>
+                          <% v = blazer_time_value(@data_source, k, v) %>
+                        <% end %>
+
+                        <% unless v.nil? %>
+                          <% if v.is_a?(String) && v == "" %>
+                            <div class="text-muted">empty string</div>
+                          <% elsif @linked_columns[k] %>
+                            <%= link_to blazer_format_value(k, v), @linked_columns[k].gsub("{value}", u(v.to_s)), target: "_blank" %>
+                          <% else %>
+                            <%= blazer_format_value(k, v) %>
+                          <% end %>
+
+                          <% if v2 = (@boom[k] || {})[v.to_s] %>
+                            <div class="text-muted"><%= v2 %></div>
+                          <% end %>
+                        <% end %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/blazer/queries/schema.html.erb
+++ b/app/views/blazer/queries/schema.html.erb
@@ -5,14 +5,17 @@
       <small><%= table[:schema] %></small>
     <% end %>
   </h4>
-  <table class="table" style="max-width: 500px;">
-    <tbody>
-      <% table[:columns].each do |column| %>
-        <tr>
-          <td style="width: 60%;"><%= column[:name] %></td>
-          <td class="text-muted"><%= column[:data_type] %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+
+  <div class="table-responsive">
+    <table class="table">
+      <tbody>
+        <% table[:columns].each do |column| %>
+          <tr>
+            <td style="width: 60%;"><%= column[:name] %></td>
+            <td class="text-muted"><%= column[:data_type] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -1,27 +1,27 @@
 <% blazer_title @query.name %>
 
-<div class="topbar">
-  <div class="container">
-    <div class="row" style="padding-top: 13px;">
-      <div class="col-sm-9">
-        <%= render partial: "blazer/nav" %>
-        <h3 style="margin: 0; line-height: 34px; display: inline;">
-          <%= @query.name %>
-        </h3>
-      </div>
-      <div class="col-sm-3 text-right">
-        <%= link_to "Edit", edit_query_path(@query, variable_params), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
-        <%= link_to "Fork", new_query_path(variable_params.merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
+<% content_for :topbar do %>
+  <div class="topbar">
+    <div class="container">
+      <div class="row" style="padding-top: 13px;">
+        <div class="col-sm-6 col-xs-12">
+          <h3 style="margin: 0; line-height: 34px; display: inline;">
+            <%= @query.name %>
+          </h3>
+        </div>
+        <div class="col-sm-6 col-xs-12 text-right">
+          <%= render partial: "blazer/nav" %>
+          <%= link_to "Edit", edit_query_path(@query, variable_params), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
+          <%= link_to "Fork", new_query_path(variable_params.merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
 
-        <% if !@error && @success %>
-          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv"), params: {statement: @statement}, class: "btn btn-primary" %>
-        <% end %>
+          <% if !@error && @success %>
+            <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv"), params: {statement: @statement}, class: "btn btn-primary" %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
-
-<div style="margin-bottom: 60px;"></div>
+<% end %>
 
 <% if @sql_errors.any? %>
   <div class="alert alert-danger">

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -49,7 +49,7 @@
   <script>
     function showRun(data) {
       $("#results").html(data);
-      $("#results table").stupidtable().stickyTableHeaders({fixedOffset: 60});
+      $("#results table").stupidtable().stickyTableHeaders({fixedOffset: 0});
     }
 
     function showError(message) {

--- a/app/views/layouts/blazer/application.html.erb
+++ b/app/views/layouts/blazer/application.html.erb
@@ -4,6 +4,7 @@
     <title><%= blazer_title ? blazer_title : "Blazer" %></title>
 
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <%= stylesheet_link_tag "blazer/application" %>
     <%= javascript_include_tag "blazer/application" %>
@@ -19,7 +20,8 @@
     <% end %>
     <%= csrf_meta_tags %>
   </head>
-  <body>
+  <body <% unless content_for?(:topbar) %>class="no-topbar"<% end %>>
+    <%= yield(:topbar) if content_for?(:topbar) %>
     <div class="container">
       <%= yield %>
     </div>

--- a/lib/blazer/adapters/elasticsearch_adapter.rb
+++ b/lib/blazer/adapters/elasticsearch_adapter.rb
@@ -16,10 +16,12 @@ module Blazer
           else
             hits = response["hits"]["hits"]
             if hits.empty? && aggregations = response["aggregations"]
-              key = aggregations.keys.first
-              aggregation = aggregations[key]["buckets"]
-              columns = aggregation.first.keys
-              rows = aggregation.collect { |a| a.values }
+              unless aggregations.empty?
+                key = aggregations.keys.first
+                aggregation = aggregations[key]["buckets"]
+                columns = aggregation.first.keys
+                rows = aggregation.collect { |a| a.values }
+              end
             else
               source_keys = hits.flat_map { |r| r["_source"].keys }.uniq
               hit_keys = (hits.first.try(:keys) || []) - ["_source"]


### PR DESCRIPTION
I noticed there were a few areas that weren't mobile responsive:
- Tables
- Top Bar

To accomodate this:
- Added `table-responsive` divs (bootstrap) around the tables
  - this wasn't enough for large tables in queries on large screens, so I also added a slight dashed board to the table outline and made it scroll to match the behaviour bootstrap does on mobile
- Added a `yield :topbar` which lets us get rid of the `position: fixed` and use dynamic height.
  - This is outside the container, so position fixed isn't necessary
  - I converted top navs over to this format.
- Changed some `float: right` styles to `pull-right` classes from bootstrap
- Moved `blazer/nav` to the right to make room for the title on mobile and to simple consolidate buttons

**All views should be roughly the same....**

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/3074765/18942934/61f247e8-85ea-11e6-8169-30fd2d154d7b.png) | ![image](https://cloud.githubusercontent.com/assets/3074765/18942946/756d892c-85ea-11e6-8bbc-9091f0b56f6b.png) |

**Or better!**

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/3074765/18943123/8baec312-85eb-11e6-8811-32e2881bbd3e.png) | ![image](https://cloud.githubusercontent.com/assets/3074765/18942978/a7bccc44-85ea-11e6-97ff-ea45e421bd18.png) |
| ![image](https://cloud.githubusercontent.com/assets/3074765/18943049/1cd1d812-85eb-11e6-985b-489f06b46291.png) | ![image](https://cloud.githubusercontent.com/assets/3074765/18943059/23a5c25c-85eb-11e6-982b-021e58438f0a.png) |
| ![image](https://cloud.githubusercontent.com/assets/3074765/18943566/74d9d80e-85ee-11e6-883e-5604ff3990f7.png) | ![image](https://cloud.githubusercontent.com/assets/3074765/18943939/a0a418f8-85f0-11e6-8628-bc9e8208754e.png) |

cc @ankane 
