### PR TITLE
Add prefix to query name when it forked

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -39,7 +39,9 @@ module Blazer
         name: params[:name]
       )
       if params[:fork_query_id]
-        @query.statement ||= Blazer::Query.find(params[:fork_query_id]).try(:statement)
+        query = Blazer::Query.find_by(id: params[:fork_query_id])
+        @query.statement ||= query.try(:statement)
+        @query.name = "Forked: #{query.try(:name)}"
       end
     end
 


### PR DESCRIPTION
Hello,

When I fork a query, I always confuse origin query with forked query. To prevent this mistake, I tried to add prefix `Forked` to query name.

Please let me know your thoughts.

Thanks!