### PR TITLE
Set schema search_path when schemas specified

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -13,6 +13,14 @@ module Blazer
             end
             establish_connection(data_source.settings["url"]) if data_source.settings["url"]
           end
+
+        setup_schemas
+      end
+
+      def setup_schemas
+        return if !postgresql? || schemas.empty?
+        schema_sql = 'SET search_path TO ' + schemas.join(',')
+        execute(schema_sql)
       end
 
       def run_statement(statement, comment)


### PR DESCRIPTION
Adding functionality to make schemas: [‘example’,’other’] work by default and make non standard schema names work as well

Whenever a blazer.yml has schemas for a datasource set the search path
for this connection to enable the access of this table with standard
SQL statements.

PostgreSQL specific