### PR TITLE
Feature - query download adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,12 @@ audit: true
 # from_email: blazer@example.org
 ```
 
+## Tests
+
+```
+bundle exec rake test
+```
+
 ## TODO
 
 - advanced permissions

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.name = :test
+  t.libs << "test"
+  t.libs << "app/adapters"
+  t.test_files = FileList['test/**/*_test.rb']
+end

--- a/app/adapters/application_adapter.rb
+++ b/app/adapters/application_adapter.rb
@@ -1,6 +1,6 @@
 class ApplicationAdapter
 
-  attr_accessor :format, :render_method
+  attr_reader :format, :render_method
 
   def initialize(query, columns, rows, data_source)
     @query = query
@@ -8,6 +8,12 @@ class ApplicationAdapter
     @rows = rows
     @data_source = data_source
     @format = self.class.format
+  end
+
+  class << self
+    def format
+      'undefined'
+    end
   end
 
 end

--- a/app/adapters/application_adapter.rb
+++ b/app/adapters/application_adapter.rb
@@ -1,0 +1,13 @@
+class ApplicationAdapter
+
+  attr_accessor :format, :render_method
+
+  def initialize(query, columns, rows, data_source)
+    @query = query
+    @columns = columns
+    @rows = rows
+    @data_source = data_source
+    @format = self.class.format
+  end
+
+end

--- a/app/adapters/query/csv_adapter.rb
+++ b/app/adapters/query/csv_adapter.rb
@@ -1,0 +1,34 @@
+class Query::CsvAdapter < SendDataAdapter
+
+  class << self
+
+    def format
+      :csv
+    end
+
+  end
+
+  protected
+
+  def mime_type
+    'text/csv'
+  end
+
+  def file_content
+    csv_data(@columns, @rows, @data_source)
+  end
+
+  def csv_data(columns, rows, data_source)
+    CSV.generate do |csv|
+      csv << columns
+      rows.each do |row|
+        csv << row.each_with_index.map { |v, i| v.is_a?(Time) ? blazer_time_value(data_source, columns[i], v) : v }
+      end
+    end
+  end
+
+  def blazer_time_value(data_source, k, v)
+    data_source.local_time_suffix.any? { |s| k.ends_with?(s) } ? v.to_s.sub(" UTC", "") : v.in_time_zone(Blazer.time_zone)
+  end
+
+end

--- a/app/adapters/query/html_adapter.rb
+++ b/app/adapters/query/html_adapter.rb
@@ -1,0 +1,17 @@
+class Query::HtmlAdapter < RenderAdapter
+
+  def render_params
+    [
+      { layout: false }
+    ]
+  end
+
+  class << self
+
+    def format
+      :html
+    end
+
+  end
+
+end

--- a/app/adapters/render_adapter.rb
+++ b/app/adapters/render_adapter.rb
@@ -1,0 +1,8 @@
+class RenderAdapter < ApplicationAdapter
+
+  def initialize(*args)
+    @render_method = :render
+    super(*args)
+  end
+
+end

--- a/app/adapters/send_data_adapter.rb
+++ b/app/adapters/send_data_adapter.rb
@@ -1,0 +1,45 @@
+class SendDataAdapter < ApplicationAdapter
+
+  def initialize(*args)
+    @render_method = :send_data
+    super(*args)
+  end
+
+  def render_params
+    [
+      file_content,
+      {
+        type: file_type,
+        disposition: disposition
+      }
+    ]
+  end
+
+
+  protected
+
+  def file_content
+    'not implemented'
+  end
+
+  def file_type
+    "#{mime_type}; charset=#{charset}; header=present"
+  end
+
+  def disposition
+    "attachment; filename=\"#{filename}\""
+  end
+
+  def mime_type
+    'text/plain'
+  end
+
+  def charset
+    'utf-8'
+  end
+
+  def filename
+    "#{@query.try(:name).try(:parameterize).presence || 'query'}.#{@format}"
+  end
+
+end

--- a/app/assets/stylesheets/blazer/application.css
+++ b/app/assets/stylesheets/blazer/application.css
@@ -47,6 +47,15 @@ input.search:focus {
   outline: none;
 }
 
+.btn-group .button_to .btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.btn-group .button_to + .dropdown-toggle {
+  position: absolute;
+}
+
 .form-inline .selectize-control, .text-right .selectize-control {
   display: inline-block;
   vertical-align: middle;

--- a/app/assets/stylesheets/blazer/application.css
+++ b/app/assets/stylesheets/blazer/application.css
@@ -54,6 +54,29 @@ input.search:focus {
 
 .btn-group .button_to + .dropdown-toggle {
   position: absolute;
+  top: 0px;
+  right: -34px;
+}
+
+.dropdown-menu > li > form {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857143;
+    color: #333;
+    white-space: nowrap;
+}
+
+.dropdown-menu > li > form > input[type="submit"] {
+  border: none;
+  background: transparent;
+}
+
+.dropdown-menu > li > form:hover {
+  color: #262626;
+  text-decoration: none;
+  background-color: #f5f5f5;
 }
 
 .form-inline .selectize-control, .text-right .selectize-control {

--- a/app/views/blazer/queries/_download.html.erb
+++ b/app/views/blazer/queries/_download.html.erb
@@ -1,0 +1,12 @@
+<div class="btn-group" style="vertical-align: top; margin-right: 5px;">
+  <%= button_to "Download csv", run_queries_path(query_id: @query.id, format: 'csv'), params: {statement: @statement}, class: "btn btn-primary" %>
+  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="caret"></span>
+    <span class="sr-only">Toggle Dropdown</span>
+  </button>
+  <ul class="dropdown-menu">
+    <% Blazer.query_adapters.each do |adapter| %>
+      <li><%= link_to "Download #{adapter.format}", run_queries_path(query_id: @query.id, format: adapter.format), params: {statement: @statement} %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/blazer/queries/_download.html.erb
+++ b/app/views/blazer/queries/_download.html.erb
@@ -6,7 +6,7 @@
   </button>
   <ul class="dropdown-menu">
     <% Blazer.query_adapters.each do |adapter| %>
-      <li><%= link_to "Download #{adapter.format}", run_queries_path(query_id: @query.id, format: adapter.format), params: {statement: @statement} %></li>
+      <li><%= button_to "Download #{adapter.format}", run_queries_path(query_id: @query.id, format: adapter.format), params: {statement: @statement} %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -3,18 +3,19 @@
 <div class="topbar">
   <div class="container">
     <div class="row" style="padding-top: 13px;">
-      <div class="col-sm-9">
+      <div class="col-sm-8">
         <%= render partial: "blazer/nav" %>
         <h3 style="margin: 0; line-height: 34px; display: inline;">
           <%= @query.name %>
         </h3>
       </div>
-      <div class="col-sm-3 text-right">
+      <div class="col-sm-2 text-right">
         <%= link_to "Edit", edit_query_path(@query, variable_params), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
         <%= link_to "Fork", new_query_path(variable_params.merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
-
+      </div>
+      <div class="col-sm-2">
         <% if !@error && @success %>
-          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv"), params: {statement: @statement}, class: "btn btn-primary" %>
+          <%= render partial: 'blazer/queries/download' %>
         <% end %>
       </div>
     </div>

--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails"
+  spec.add_dependency "mocha"
   spec.add_dependency "chartkick"
   spec.add_dependency "safely_block", ">= 0.1.1"
 

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -32,6 +32,7 @@ module Blazer
     attr_accessor :anomaly_checks
     attr_accessor :async
     attr_accessor :images
+    attr_accessor :query_adapters
     attr_accessor :query_editable
   end
   self.audit = true
@@ -65,6 +66,16 @@ module Blazer
       else
         {}
       end
+    end
+  end
+
+  def self.query_adapters
+    @query_adapters = begin
+      settings['query_adapters'].map do |adapter_name|
+        adapter_name.constantize
+      end
+    rescue => e
+      nil
     end
   end
 

--- a/lib/generators/blazer/templates/config.yml
+++ b/lib/generators/blazer/templates/config.yml
@@ -57,3 +57,7 @@ check_schedules:
   - "1 day"
   - "1 hour"
   - "5 minutes"
+
+query_adapters:
+  - "::Query::HtmlAdapter"
+  - "::Query::CsvAdapter"

--- a/test/adapters/application_adapter_test.rb
+++ b/test/adapters/application_adapter_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+require 'application_adapter'
+
+class ApplicationAdapterTest < Minitest::Test
+
+  TEST_FORMAT_ADAPTER_FORMAT = :test
+
+  class TestAdapter < ApplicationAdapter
+    class << self
+
+      def format
+        TEST_FORMAT_ADAPTER_FORMAT
+      end
+
+    end
+  end
+
+  def test_can_instanciate
+    adapter = ApplicationAdapter.new(nil, nil, nil, nil)
+
+    refute_nil adapter
+  end
+
+  def test_can_set_attributes_on_initialization
+    query = 'query'
+    columns = 'columns'
+    rows = 'rows'
+    data_source = 'data_source'
+    adapter = ApplicationAdapter.new(query, columns, rows, data_source)
+
+    assert_equal query, adapter.instance_variable_get(:@query)
+    assert_equal columns, adapter.instance_variable_get(:@columns)
+    assert_equal rows, adapter.instance_variable_get(:@rows)
+    assert_equal data_source, adapter.instance_variable_get(:@data_source)
+  end
+
+  def test_can_set_format_when_class_method_overrided
+    adapter = TestAdapter.new(nil, nil, nil, nil)
+
+    assert_equal TEST_FORMAT_ADAPTER_FORMAT, adapter.format
+  end
+
+  def test_cannot_rewrite_attributes_from_outside
+    adapter = TestAdapter.new(nil, nil, nil, nil)
+
+    assert_raises(NoMethodError) { adapter.format = :bad_format }
+    assert_raises(NoMethodError) { adapter.render_method = :bad_render_method }
+    assert_equal TEST_FORMAT_ADAPTER_FORMAT, adapter.format
+    assert_nil adapter.render_method
+  end
+
+end

--- a/test/adapters/render_adapter_test.rb
+++ b/test/adapters/render_adapter_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'render_adapter'
+
+class RenderAdapterTest < Minitest::Test
+
+  RENDER_METHOD = :render
+
+  def test_can_instanciate
+    adapter = RenderAdapter.new(nil, nil, nil, nil)
+
+    refute_nil adapter
+  end
+
+  def test_overrides_render_method
+    adapter = RenderAdapter.new(nil, nil, nil, nil)
+
+    assert_equal RENDER_METHOD, adapter.render_method
+  end
+
+  def test_can_still_set_attributes_on_initialization
+    query = 'query'
+    columns = 'columns'
+    rows = 'rows'
+    data_source = 'data_source'
+    adapter = RenderAdapter.new(query, columns, rows, data_source)
+
+    assert_equal query, adapter.instance_variable_get(:@query)
+    assert_equal columns, adapter.instance_variable_get(:@columns)
+    assert_equal rows, adapter.instance_variable_get(:@rows)
+    assert_equal data_source, adapter.instance_variable_get(:@data_source)
+  end
+
+end

--- a/test/adapters/send_data_test.rb
+++ b/test/adapters/send_data_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+require 'send_data_adapter'
+
+class SendDataAdapterTest < Minitest::Test
+
+  class TestAdapter < SendDataAdapter
+
+    class << self
+      def format
+        ADAPTER_FORMAT
+      end
+    end
+
+    protected
+
+    def disposition
+      "attachment; filename=\"#{filename}\""
+    end
+
+    def mime_type
+      ADAPTER_MIME_TYPE
+    end
+
+    def charset
+      ADAPTER_CHARSET
+    end
+
+    def file_content
+      ADAPTER_FILE_CONTENT
+    end
+
+    def filename
+      ADAPTER_FILENAME
+    end
+
+  end
+
+  ADAPTER_FORMAT = :test
+  ADAPTER_FILENAME = 'test.test'.freeze
+  ADAPTER_CHARSET = 'test'.freeze
+  ADAPTER_FILE_CONTENT = 'test'.freeze
+  ADAPTER_MIME_TYPE = 'text/test'.freeze
+  RENDER_METHOD = :send_data
+
+  def test_can_instanciate
+    adapter = SendDataAdapter.new(nil, nil, nil, nil)
+
+    refute_nil adapter
+  end
+
+  def test_overrides_render_method
+    adapter = SendDataAdapter.new(nil, nil, nil, nil)
+
+    assert_equal RENDER_METHOD, adapter.render_method
+  end
+
+  def test_can_still_set_attributes_on_initialization
+    query = 'query'
+    columns = 'columns'
+    rows = 'rows'
+    data_source = 'data_source'
+    adapter = SendDataAdapter.new(query, columns, rows, data_source)
+
+    assert_equal query, adapter.instance_variable_get(:@query)
+    assert_equal columns, adapter.instance_variable_get(:@columns)
+    assert_equal rows, adapter.instance_variable_get(:@rows)
+    assert_equal data_source, adapter.instance_variable_get(:@data_source)
+  end
+
+  def test_can_override_methods
+    adapter = TestAdapter.new(nil, nil, nil, nil)
+
+    assert_equal ADAPTER_FORMAT, adapter.format
+    assert_equal ADAPTER_FILENAME, adapter.send(:filename)
+    assert_equal ADAPTER_CHARSET, adapter.send(:charset)
+    assert_equal ADAPTER_FILE_CONTENT, adapter.send(:file_content)
+    assert_equal ADAPTER_MIME_TYPE, adapter.send(:mime_type)
+    assert_equal "attachment; filename=\"#{ADAPTER_FILENAME}\"", adapter.send(:disposition)
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,3 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/mini_test'


### PR DESCRIPTION
While downloading queries results, we can only have it in CSV and that's quite sad because it's not enhanceable from outside the gem.

I've done an adapter system that allows applications using `blazer` to define their own adapters to download queries in multiple formats (e.g: json, pdf, etc.).
Adapters classes are explicitly given while configuring Blazer, in `blazer.yml`.

2 "base" adapters are present in the app: `RenderAdapter` and `SendDataAdapter`.
Basically, every adapter that wants to render something inherits from `RenderAdapter` and every one that wants to make user download something inherits from `SendDataAdapter`.

I've also added some tests.