### PR TITLE
Deterministic sort for floats with empty values in Firefox

### DIFF
--- a/app/assets/javascripts/blazer/stupidtable.js
+++ b/app/assets/javascripts/blazer/stupidtable.js
@@ -95,7 +95,7 @@
       return parseInt(a.replace(/,/g, ''), 10) - parseInt(b.replace(/,/g, ''), 10);
     },
     "float": function(a, b) {
-      return parseFloat(a) - parseFloat(b);
+      return (parseFloat(a) || 0) - (parseFloat(b) || 0);
     },
     "string": function(a, b) {
       if (a < b) return -1;


### PR DESCRIPTION
The sorting of stupidtable was not deterministic for columns with `float` and `NULL` values in Firefox.

*Before:*
![image](https://cloud.githubusercontent.com/assets/2269084/23524480/1a82450a-ff8b-11e6-89a7-9b1187dedd0f.png)

*After:*
![image](https://cloud.githubusercontent.com/assets/2269084/23524490/2c60d624-ff8b-11e6-97df-5fa30a54b4e5.png)

