### PR TITLE
Update installation instruction on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ gem 'blazer'
 Run:
 
 ```sh
+rails bundle install
 rails g blazer:install
 rake db:migrate
 ```


### PR DESCRIPTION
I added a line to run 'bundle install' before running 'rails g blazer:install'

I typically copy and paste installation instructions line by line, and I got an error the first time I tried to install before I realized that I didn't run 'bundle install'