### PR TITLE
Improve slack implementation

### DIFF
--- a/app/mailers/blazer/check_mailer.rb
+++ b/app/mailers/blazer/check_mailer.rb
@@ -32,7 +32,7 @@ module Blazer
       notifier = Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
                                                                username: 'Blazer Notifier'
 
-      notifier.ping "Check #{name} failing. @etavenn @skatkov @channel"
+      notifier.ping "Check #{name} failing. http://107.170.251.230/queries/52-unrecognized-priviliged-user @etavenn @skatkov @channel"
     end
   end
 end

--- a/app/mailers/blazer/check_mailer.rb
+++ b/app/mailers/blazer/check_mailer.rb
@@ -17,22 +17,24 @@ module Blazer
       @rows = rows
       @column_types = column_types
       @check_type = check_type
-      notify_slack(check.query.name)
+      notify_slack("#{check.query.name} check went from #{@state_was} to #{@state}.")
       mail to: check.emails, reply_to: check.emails, subject: "Check #{state.titleize}: #{check.query.name}"
     end
 
     def failing_checks(email, checks)
       @checks = checks
-      notify_slack("about security")
+      notify_slack("#{pluralize(checks.size, "Check")} Failing. #{checks.each { |c| puts c.query.name }}")
       # add reply_to for mailing lists
       mail to: email, reply_to: email, subject: "#{pluralize(checks.size, "Check")} Failing"
     end
 
-    def notify_slack(name)
-      notifier = Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
-                                                               username: 'Blazer Notifier'
+    def notify_slack(message)
+      slack_notifier.ping("#{message} @alessio @etavenn @skatkov @channel")
+    end
 
-      notifier.ping "Check #{name} failing. http://107.170.251.230/queries/52-unrecognized-priviliged-user @etavenn @skatkov @channel"
+    def slack_notifier
+      Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
+                                                    username: 'Blazer Notifier'
     end
   end
 end

--- a/app/mailers/blazer/check_mailer.rb
+++ b/app/mailers/blazer/check_mailer.rb
@@ -1,3 +1,5 @@
+require 'slack-notifier'
+
 module Blazer
   class CheckMailer < ActionMailer::Base
     include ActionView::Helpers::TextHelper
@@ -15,13 +17,22 @@ module Blazer
       @rows = rows
       @column_types = column_types
       @check_type = check_type
+      notify_slack(check.query.name)
       mail to: check.emails, reply_to: check.emails, subject: "Check #{state.titleize}: #{check.query.name}"
     end
 
     def failing_checks(email, checks)
       @checks = checks
+      notify_slack("about security")
       # add reply_to for mailing lists
       mail to: email, reply_to: email, subject: "#{pluralize(checks.size, "Check")} Failing"
+    end
+
+    def notify_slack(name)
+      notifier = Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
+                                                               username: 'Blazer Notifier'
+
+      notifier.ping "Check #{name} failing. @etavenn @skatkov @channel"
     end
   end
 end

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -1,0 +1,21 @@
+require 'slack-notifier'
+
+module Blazer
+  class SlackNotifier
+    def state_change(check, state, state_was, rows_count)
+      message = "#{check} check changed status from #{state_was} to #{state}. It now returns #{rows} rows. #{query_url(check.query_id)}"
+      notifier.ping(message)
+    end
+
+    def failing_checks(checks)
+      msg = "#{pluralize(checks.size, "Check")} failing.\n"
+      checks.each { |c| msg << "#{query_url(check.query_id)} (#{check.state})" }
+      notifier.ping(msg)
+    end
+
+    def notifier
+      Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: ENV.fetch('SLACK_CHANNEL'),
+                                                    username: ENV.fetch('SLACK_USERNAME')
+    end
+  end
+end

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -1,3 +1,5 @@
+require 'slack-notifier'
+
 module Blazer
   class Check < ActiveRecord::Base
     belongs_to :creator, Blazer::BELONGS_TO_OPTIONAL.merge(class_name: Blazer.user_class.to_s) if Blazer.user_class
@@ -61,6 +63,10 @@ module Blazer
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
+        notifier = Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
+                                                                 username: 'Blazer Notifier'
+
+        notifier.ping "A new user has been granted admin access. @etavenn @skatkov @channel"
       end
       save! if changed?
     end

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -63,10 +63,7 @@ module Blazer
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
-        notifier = Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: '#info-production',
-                                                                 username: 'Blazer Notifier'
-
-        notifier.ping "A new user has been granted admin access. @etavenn @skatkov @channel"
+        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size)
       end
       save! if changed?
     end

--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
   spec.add_dependency "chartkick"
+  spec.add_dependency "slack-notifier"
   spec.add_dependency "safely_block", ">= 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -153,6 +153,7 @@ module Blazer
     emails.each do |email, checks|
       Safely.safely do
         Blazer::CheckMailer.failing_checks(email, checks).deliver_now
+        Blazer::SlackNotifier.failing_checks(checks)
       end
     end
   end


### PR DESCRIPTION
As Stas was saying here (https://github.com/ankane/blazer/issues/145) I was working on adding Slack support for Blazer checks. Right now it works by reading Webhook URL, channel and username from ENV variables but obviously that's not optimal. I've placed the notifier in the `mailer` folder so that it'd be automatically loaded by Rails apps. 

It'd be nice to hear suggestions about how to implement this further; I was thinking of adding Slack options for each check in the same way that emails do, but each channel requires a specific webhook URL, so maybe a default channel would be best so the webhook can be hidden in `.env`. I was thinking about the ability to append to the message as well, for example to add Slack `@s` of people who should be interested in it. 