### PR TITLE
Default presto schema

### DIFF
--- a/lib/blazer/adapters/presto_adapter.rb
+++ b/lib/blazer/adapters/presto_adapter.rb
@@ -34,7 +34,7 @@ module Blazer
           Presto::Client.new(
             server: "#{uri.host}:#{uri.port}",
             catalog: uri.path.to_s.sub(/\A\//, ""),
-            schema: query["schema"] || "public",
+            schema: query["schema"] || "default",
             user: uri.user,
             http_debug: false
           )


### PR DESCRIPTION
The default presto schema is named `default` and not `public`