### PR TITLE
Specify where to define before_action method in README under Authenti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Specify a `before_action` method to run in `blazer.yml`.
 ```yml
 before_action: require_admin
 ```
+Then define the custom authentication method in your `application_controller.rb`.
+
+```ruby
+def require_admin
+  # depending on your auth, maybe something like...
+  current_user && current_user.admin?
+end
+```
 
 ## Queries
 


### PR DESCRIPTION
…cation > Other

I couldn't figure out from the docs how to use `before_action` in `blazer.yml`. With help from @cmckni3 on [stackoverflow](https://stackoverflow.com/questions/45849750/custom-authentication-for-blazer-rails), defining the custom auth method in `application_controller.rb` seems to work, but I'm not entirely sure that's what was intended.

If it is, I've taken a shot at adding to the docs on where to put the auth method.

Thanks for your work on blazer. It's amazing.

Justin