### PR TITLE
Specify rails version

### DIFF
--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails"
+  spec.add_dependency "rails", ">= 4"
   spec.add_dependency "chartkick"
   spec.add_dependency "safely_block", ">= 0.1.1"
 


### PR DESCRIPTION
I'm working on a bit of a crusty rails (internal) app stuck on version 3, and I was hoping to use blazer for some simple reporting but realized it wouldn't work when I got this error.
```
Routing Error

undefined method `skip_action_callback' for Blazer::BaseController:Class
Did you mean?  skip_callback
```

So this pull request is to let everyone know it only works on rails 4 and above and don't go down the same path I did. :grimacing: