### PR TITLE
feat(Checks): add Slack notifications

### DIFF
--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -46,7 +46,7 @@ module Blazer
     private
 
       def check_params
-        params.require(:check).permit(:query_id, :emails, :invert, :check_type, :schedule)
+        params.require(:check).permit(:query_id, :emails, :invert, :check_type, :schedule, :notify_slack)
       end
 
       def set_check

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -6,21 +6,20 @@ module Blazer
 
     def self.state_change(check, state, state_was, rows_count)
       message = "#{check.query.name} check changed status from #{state_was} to #{state}. It now returns #{rows} rows."
-      notify_slack(message, check.slack_channel)
+      notify_slack(message)
     end
 
     def self.failing_checks(checks, channel)
       message = "Checks failing.\n"
       checks.each { |c| message << "#{c.query.name} (#{c.state})\n" }
-      notify_slack(message, channel)
+      notify_slack(message)
     end
 
-    def self.notify_slack(message, channel)
+    def self.notify_slack(message)
       slack_url = ENV.fetch('SLACK_WEBHOOK_URL')
 
       params = {
-        text: message,
-        channel: channel
+        text: message
       }
 
       uri = URI.parse(slack_url)

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -2,8 +2,6 @@ require 'net/http'
 
 module Blazer
   class SlackNotifier
-    include Rails.application.routes.url_helpers
-
     def self.state_change(check, state, state_was, rows_count)
       message = "#{check.query.name} check changed status from #{state_was} to #{state}. It now returns #{rows} rows."
       notify_slack(message)

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -1,0 +1,25 @@
+require 'slack-notifier'
+
+module Blazer
+  class SlackNotifier
+    def state_change(check, state, state_was, rows_count)
+      message = "#{check} check changed status from #{state_was} to #{state}. It now returns #{rows} rows. #{query_url(check.query_id)}"
+      notify_slack(message, check.slack_channel)
+    end
+
+    def failing_checks(checks)
+      message = "#{pluralize(checks.size, "Check")} failing.\n"
+      checks.each { |c| message << "#{query_url(check.query_id)} (#{check.state})" }
+      notify_slack(message, checks.first.slack_channel)
+    end
+
+    def notify_slack(message, channel)
+      notifier(channel).ping(message)
+    end
+
+    def notifier(channel)
+      Slack::Notifier.new ENV.fetch('WEBHOOK_URL'), channel: channel,
+                                                    username: 'Blazer Notifier'
+    end
+  end
+end

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -3,13 +3,13 @@ require 'slack-notifier'
 module Blazer
   class SlackNotifier
     def state_change(check, state, state_was, rows_count)
-      message = "#{check} check changed status from #{state_was} to #{state}. It now returns #{rows} rows. #{query_url(check.query_id)}"
+      message = "#{check.query.name} check changed status from #{state_was} to #{state}. It now returns #{rows} rows. #{query_url(check.query_id)}"
       notify_slack(message, check.slack_channel)
     end
 
     def failing_checks(checks)
       message = "#{pluralize(checks.size, "Check")} failing.\n"
-      checks.each { |c| message << "#{query_url(check.query_id)} (#{check.state})" }
+      checks.each { |c| message << "#{query_url(check.query_id)} (#{check.state})\n" }
       notify_slack(message, checks.first.slack_channel)
     end
 

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -7,7 +7,7 @@ module Blazer
       notify_slack(message)
     end
 
-    def self.failing_checks(checks, channel)
+    def self.failing_checks(checks)
       message = "Checks failing.\n"
       checks.each { |c| message << "#{c.query.name} (#{c.state})\n" }
       notify_slack(message)

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -1,3 +1,5 @@
+require 'slack-notifier'
+
 module Blazer
   class Check < Record
     belongs_to :creator, Blazer::BELONGS_TO_OPTIONAL.merge(class_name: Blazer.user_class.to_s) if Blazer.user_class
@@ -61,6 +63,7 @@ module Blazer
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
+        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size)
       end
       save! if changed?
     end

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -61,7 +61,7 @@ module Blazer
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
-        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size) if slack_channel.present?
+        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size) if notify_slack
       end
       save! if changed?
     end

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -1,5 +1,3 @@
-require 'slack-notifier'
-
 module Blazer
   class Check < Record
     belongs_to :creator, Blazer::BELONGS_TO_OPTIONAL.merge(class_name: Blazer.user_class.to_s) if Blazer.user_class

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -61,7 +61,7 @@ module Blazer
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
-        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size)
+        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size) if slack_channel.present?
       end
       save! if changed?
     end

--- a/app/views/blazer/checks/_form.html.erb
+++ b/app/views/blazer/checks/_form.html.erb
@@ -60,13 +60,13 @@
     <%= f.label :emails %>
     <%= f.text_field :emails, placeholder: "Optional, comma separated", class: "form-control" %>
   </div>
-  <p class="text-muted">Emails are sent when a check starts failing, and when it starts passing again.
 
   <div class="form-group">
     <%= f.label :slack_channel %>
     <%= f.text_field :slack_channel, placeholder: "Optional, formatted as #slack-channel", class: "form-control" %>
   </div>
-  <p class="text-muted">Slack notifications are sent when a check starts failing, and when it starts passing again.
+
+  <p class="text-muted">Email and Slack notifications are sent when a check starts failing, and when it starts passing again.
   <p>
     <% if @check.persisted? %>
       <%= link_to "Delete", check_path(@check), method: :delete, "data-confirm" => "Are you sure?", class: "btn btn-danger" %>

--- a/app/views/blazer/checks/_form.html.erb
+++ b/app/views/blazer/checks/_form.html.erb
@@ -62,8 +62,8 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :slack_channel %>
-    <%= f.text_field :slack_channel, placeholder: "Optional, formatted as #slack-channel", class: "form-control" %>
+    <%= f.label :notify_slack %>
+    <%= f.check_box :notify_slack, class: "form-control" %>
   </div>
 
   <p class="text-muted">Email and Slack notifications are sent when a check starts failing, and when it starts passing again.

--- a/app/views/blazer/checks/_form.html.erb
+++ b/app/views/blazer/checks/_form.html.erb
@@ -61,6 +61,12 @@
     <%= f.text_field :emails, placeholder: "Optional, comma separated", class: "form-control" %>
   </div>
   <p class="text-muted">Emails are sent when a check starts failing, and when it starts passing again.
+
+  <div class="form-group">
+    <%= f.label :slack_channel %>
+    <%= f.text_field :slack_channel, placeholder: "Optional, formatted as #slack-channel", class: "form-control" %>
+  </div>
+  <p class="text-muted">Slack notifications are sent when a check starts failing, and when it starts passing again.
   <p>
     <% if @check.persisted? %>
       <%= link_to "Delete", check_path(@check), method: :delete, "data-confirm" => "Are you sure?", class: "btn btn-danger" %>

--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 4"
   spec.add_dependency "chartkick"
+  spec.add_dependency "slack-notifier"
   spec.add_dependency "safely_block", ">= 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 4"
   spec.add_dependency "chartkick"
-  spec.add_dependency "slack-notifier"
   spec.add_dependency "safely_block", ">= 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -155,6 +155,7 @@ module Blazer
     emails.each do |email, checks|
       Safely.safely do
         Blazer::CheckMailer.failing_checks(email, checks).deliver_now
+        Blazer::SlackNotifier.failing_checks(checks)
       end
     end
   end

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -155,7 +155,7 @@ module Blazer
       slack_checks << check if check.notify_slack
     end
 
-    Blazer::SlackNotifier.failing_checks(slack_checks)
+    Blazer::SlackNotifier.failing_checks(slack_checks) unless slack_checks.empty?
 
     emails.each do |email, checks|
       Safely.safely do

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -146,19 +146,16 @@ module Blazer
 
   def self.send_failing_checks
     emails = {}
-    slack_channels = {}
+    slack_checks = []
 
     Blazer::Check.includes(:query).where(state: ["failing", "error", "timed out", "disabled"]).find_each do |check|
-      (slack_channels[check.slack_channel] ||= []) << check
-
       check.split_emails.each do |email|
         (emails[email] ||= []) << check
       end
+      slack_checks << check if check.notify_slack
     end
 
-    slack_channels.each do |channel, checks|
-      Blazer::SlackNotifier.failing_checks(checks, channel)
-    end
+    Blazer::SlackNotifier.failing_checks(slack_checks)
 
     emails.each do |email, checks|
       Safely.safely do

--- a/lib/generators/blazer/templates/install.rb
+++ b/lib/generators/blazer/templates/install.rb
@@ -38,7 +38,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.text :emails
       t.string :check_type
       t.text :message
-      t.string :slack_channel
+      t.boolean :notify_slack, default: false
       t.timestamp :last_run_at
       t.timestamps null: false
     end

--- a/lib/generators/blazer/templates/install.rb
+++ b/lib/generators/blazer/templates/install.rb
@@ -38,6 +38,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.text :emails
       t.string :check_type
       t.text :message
+      t.text :slack_channel
       t.timestamp :last_run_at
       t.timestamps null: false
     end

--- a/lib/generators/blazer/templates/install.rb
+++ b/lib/generators/blazer/templates/install.rb
@@ -38,7 +38,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.text :emails
       t.string :check_type
       t.text :message
-      t.text :slack_channel
+      t.string :slack_channel
       t.timestamp :last_run_at
       t.timestamps null: false
     end


### PR DESCRIPTION
Adding Slack notifications for checks. 

Setup:
- Get a Webhook URL from Slack and set it as an ENV variable
- When creating a check, specify your Slack channel
- Receive Slack notifications at the same pace as email notifications