### PR TITLE
Linked columns with row values

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -28,6 +28,10 @@ module Blazer
       end
     end
 
+    def build_column_link(template, value)
+      template.gsub("{value}", url_encode(value.to_s))
+    end
+
     def blazer_maps?
       ENV["MAPBOX_ACCESS_TOKEN"].present?
     end

--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -28,8 +28,12 @@ module Blazer
       end
     end
 
-    def build_column_link(template, value)
-      template.gsub("{value}", url_encode(value.to_s))
+    def build_column_link(template, value, row, columns)
+      replaced = template.dup
+      columns.each_with_index do |col, i|
+        replaced.gsub!("{#{col}}", url_encode(row[i].to_s))
+      end
+      replaced.gsub("{value}", url_encode(value.to_s))
     end
 
     def blazer_maps?

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -139,7 +139,7 @@
                         <% if v.is_a?(String) && v == "" %>
                           <div class="text-muted">empty string</div>
                         <% elsif @linked_columns[k] %>
-                          <%= link_to blazer_format_value(k, v), build_column_link(@linked_columns[k], v), target: "_blank" %>
+                          <%= link_to blazer_format_value(k, v), build_column_link(@linked_columns[k], v, row, @columns), target: "_blank" %>
                         <% else %>
                           <%= blazer_format_value(k, v) %>
                         <% end %>

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -139,7 +139,7 @@
                         <% if v.is_a?(String) && v == "" %>
                           <div class="text-muted">empty string</div>
                         <% elsif @linked_columns[k] %>
-                          <%= link_to blazer_format_value(k, v), @linked_columns[k].gsub("{value}", u(v.to_s)), target: "_blank" %>
+                          <%= link_to blazer_format_value(k, v), build_column_link(@linked_columns[k], v), target: "_blank" %>
                         <% else %>
                           <%= blazer_format_value(k, v) %>
                         <% end %>


### PR DESCRIPTION
Implementation for #167 (and more). Basically, this change allows using any row values in linked column templates, so that if you do have nested rails resources, as long as you can somehow make sure that you have the right columns in your result table, it'll generate the links for you.

Thoughts:

- if you don't have all the necessary columns, should it not generate a URL, or just generate a bogus URL? To me it seems like it'd be best to not attempt to generate a URL if there are any interpolated values that don't exist in the row, but I haven't implemented that yet (this was mostly a small proof of concept)

- Is it a performance or security issue to gsub all column names, rather than looking for the specific values that are included in the template string? It might be slightly more efficient to first scan the string for segments that look like "{\w+}" (for instance) and then look those up in the columns list if any are found, but it seems like either way you're iterating through the columns list, and this way we need a regex which is potentially error prone. The current implementation is straightforward and just works, even if it's searching the format string N times for each column, times the number of rows. Although if you have more columns with link templates it could start to build up... but I kinda think thinking about this is premature optimization.

- I've left in the current behavior of interpolating `{value}` for the value for that column, seems useful enough to keep both options.

Any feedback is greatly appreciated!