### PR TITLE
No more to lose unsaved SQL when refreshing "queries/new" page

### DIFF
--- a/app/assets/javascripts/blazer/application.js
+++ b/app/assets/javascripts/blazer/application.js
@@ -16,6 +16,7 @@
 //= require ./routes
 //= require ./queries
 //= require ./fuzzysearch
+//= require ./draft_store
 
 Vue.config.devtools = false
 
@@ -76,4 +77,3 @@ function preventBackspaceNav() {
 }
 
 preventBackspaceNav()
-

--- a/app/assets/javascripts/blazer/draft_store.js
+++ b/app/assets/javascripts/blazer/draft_store.js
@@ -1,27 +1,24 @@
 var DraftStore = {
-  isSessionStorageSupported: function() {
-    return typeof(Storage) !== "undefined"
+  isSessionStorageSupported: function () {
+    return typeof (Storage) !== "undefined"
   },
 
-  tabID: function() {
-    return sessionStorage.tabID ? sessionStorage.tabID : sessionStorage.tabID = this._generateTabID()
+  saveDraft: function (value) {
+    if (!this.isSessionStorageSupported()) { return }
+    sessionStorage.setItem(this._tabID(), value)
   },
 
-  saveDraft: function(value) {
-    if (!this.isSessionStorageSupported()) {
-      return
-    }
-    sessionStorage.setItem(this.tabID(), value)
+  restoreDraft: function () {
+    if (!this.isSessionStorageSupported()) { return }
+    return sessionStorage.getItem(this._tabID())
   },
 
-  restoreDraft: function() {
-    if (!this.isSessionStorageSupported()) {
-      return
-    }
-    return sessionStorage.getItem(this.tabID())
+  removeDraft: function () {
+    if (!this.isSessionStorageSupported()) { return }
+    return sessionStorage.removeItem(this._tabID())
   },
 
-  _generateTabID: function() {
-    return "blazer-query-" + Math.random()
+  _tabID: function () {
+    return sessionStorage._tabID ? sessionStorage._tabID : sessionStorage._tabID = ("blazer-query-" + Math.random())
   }
 }

--- a/app/assets/javascripts/blazer/draft_store.js
+++ b/app/assets/javascripts/blazer/draft_store.js
@@ -1,0 +1,23 @@
+var DraftStore = {
+  isSessionStorageSupported: function() {
+    return typeof(Storage) !== "undefined"
+  },
+
+  tabID: function() {
+    return sessionStorage.tabID ? sessionStorage.tabID : sessionStorage.tabID = Math.random()
+  },
+
+  saveDraft: function(value) {
+    if (!this.isSessionStorageSupported()) {
+      return
+    }
+    sessionStorage.setItem("blazer-query-" + this.tabID(), value)
+  },
+
+  restoreDraft: function() {
+    if (!this.isSessionStorageSupported()) {
+      return
+    }
+    return sessionStorage.getItem("blazer-query-" + this.tabID())
+  }
+}

--- a/app/assets/javascripts/blazer/draft_store.js
+++ b/app/assets/javascripts/blazer/draft_store.js
@@ -4,20 +4,24 @@ var DraftStore = {
   },
 
   tabID: function() {
-    return sessionStorage.tabID ? sessionStorage.tabID : sessionStorage.tabID = Math.random()
+    return sessionStorage.tabID ? sessionStorage.tabID : sessionStorage.tabID = this._generateTabID()
   },
 
   saveDraft: function(value) {
     if (!this.isSessionStorageSupported()) {
       return
     }
-    sessionStorage.setItem("blazer-query-" + this.tabID(), value)
+    sessionStorage.setItem(this.tabID(), value)
   },
 
   restoreDraft: function() {
     if (!this.isSessionStorageSupported()) {
       return
     }
-    return sessionStorage.getItem("blazer-query-" + this.tabID())
+    return sessionStorage.getItem(this.tabID())
+  },
+
+  _generateTabID: function() {
+    return "blazer-query-" + Math.random()
   }
 }

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -67,6 +67,7 @@
 <script>
   <%= blazer_js_var "params", variable_params %>
   <%= blazer_js_var "previewStatement", Hash[Blazer.data_sources.map { |k, v| [k, (v.preview_statement rescue "")] }] %>
+  var new_record = <%= @query.new_record? %>;
 
   var app = new Vue({
     el: "#app",
@@ -98,9 +99,7 @@
           _this.running = false
           _this.showResults(data)
 
-          <% if @query.new_record? %>
-            DraftStore.saveDraft(_this.getSQL())
-          <% end %>
+          if (new_record) { DraftStore.saveDraft(_this.getSQL()) }
 
           errorLine = _this.getErrorLine()
           if (errorLine) {
@@ -169,10 +168,10 @@
 
         this.editor = editor
 
-        <% if @query.new_record? %>
+        if (new_record) {
           var draftSQL = DraftStore.restoreDraft()
           if (draftSQL) { editor.setValue(draftSQL) }
-        <% end %>
+        }
 
         editor.getSession().on("change", function () {
           $("#query_statement").val(editor.getValue())

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -98,6 +98,8 @@
           _this.running = false
           _this.showResults(data)
 
+          DraftStore.saveDraft(_this.getSQL())
+
           errorLine = _this.getErrorLine()
           if (errorLine) {
             editor.getSession().addGutterDecoration(errorLine - 1, "error")
@@ -164,6 +166,9 @@
         editor.commands.removeCommands(["gotoline", "find"])
 
         this.editor = editor
+
+        var draftSQL = DraftStore.restoreDraft()
+        if (draftSQL) { editor.setValue(draftSQL) }
 
         editor.getSession().on("change", function () {
           $("#query_statement").val(editor.getValue())

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -98,7 +98,9 @@
           _this.running = false
           _this.showResults(data)
 
-          DraftStore.saveDraft(_this.getSQL())
+          <% if @query.new_record? %>
+            DraftStore.saveDraft(_this.getSQL())
+          <% end %>
 
           errorLine = _this.getErrorLine()
           if (errorLine) {
@@ -167,8 +169,10 @@
 
         this.editor = editor
 
-        var draftSQL = DraftStore.restoreDraft()
-        if (draftSQL) { editor.setValue(draftSQL) }
+        <% if @query.new_record? %>
+          var draftSQL = DraftStore.restoreDraft()
+          if (draftSQL) { editor.setValue(draftSQL) }
+        <% end %>
 
         editor.getSession().on("change", function () {
           $("#query_statement").val(editor.getValue())

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -67,7 +67,7 @@
 <script>
   <%= blazer_js_var "params", variable_params %>
   <%= blazer_js_var "previewStatement", Hash[Blazer.data_sources.map { |k, v| [k, (v.preview_statement rescue "")] }] %>
-  var new_record = <%= @query.new_record? %>;
+  var new_record = <%= @query.new_record? && @query.statement.blank? %>;
 
   var app = new Vue({
     el: "#app",
@@ -98,8 +98,6 @@
         runQuery(data, function (data) {
           _this.running = false
           _this.showResults(data)
-
-          if (new_record) { DraftStore.saveDraft(_this.getSQL()) }
 
           errorLine = _this.getErrorLine()
           if (errorLine) {
@@ -177,6 +175,7 @@
         }
 
         editor.getSession().on("change", function () {
+          if (new_record) { DraftStore.saveDraft(editor.getValue()) }
           $("#query_statement").val(editor.getValue())
           _this.adjustHeight()
         })
@@ -248,4 +247,5 @@
       this.showEditor()
     }
   })
+  $("form").submit(function() { DraftStore.removeDraft() })
 </script>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -170,7 +170,10 @@
 
         if (new_record) {
           var draftSQL = DraftStore.restoreDraft()
-          if (draftSQL) { editor.setValue(draftSQL) }
+          if (draftSQL) {
+            editor.setValue(draftSQL)
+            $("#query_statement").val(draftSQL)
+          }
         }
 
         editor.getSession().on("change", function () {


### PR DESCRIPTION
## What

* Cache SQLs on "queries/new" page while you're typing, so you won't lose your queries if the browser get closed (or go back to previous page) accidentally.
* Multi-tab is also supported, so the data won't be mixed up even there are multiple tabs.

Note:
* Since it uses `sessionStorage`, we can't restore the data if you open a new tab, you have to restore the data in the original tab.