### PR TITLE
Add query variable to the filename for downloads

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -254,7 +254,10 @@ module Blazer
             render layout: false
           end
           format.csv do
-            send_data csv_data(@columns, @rows, @data_source), type: "text/csv; charset=utf-8; header=present", disposition: "attachment; filename=\"#{@query.try(:name).try(:parameterize).presence || 'query'}.csv\""
+            params = variable_params.select { |k| @query.variables.include?(k) }
+            name = @query.try(:name).presence || "query"
+            filename = "#{name}-#{params.to_query}".parameterize + ".csv"
+            send_data csv_data(@columns, @rows, @data_source), type: "text/csv; charset=utf-8; header=present", disposition: "attachment; filename=\"#{filename}\""
           end
         end
       end


### PR DESCRIPTION
## Problem
When one downloads the result of a query that has variables, the filename does not indicate which values were used. This is confusing when it has to be done for multiple values of the variables (no way to distinguish which saved file belong to what combination of variables).

## Solution
This parch includes query variables and their values into the filename.

## Example
**Given** 
A query named "example-query" with 2 variables "a" and "b" has been run with a=1 and b=2.
**Actual** 
The filename, when downloaded, is _example-query.csv_.
**Proposed**
The filename, when downloaded, is _example-query-a-1-b-2.csv_


