### PR TITLE
Fix for BigQuery adapter with version 1.8

### DIFF
--- a/lib/blazer/adapters/bigquery_adapter.rb
+++ b/lib/blazer/adapters/bigquery_adapter.rb
@@ -10,7 +10,8 @@ module Blazer
           options = {}
           options[:timeout] = data_source.timeout.to_i * 1000 if data_source.timeout
           results = bigquery.query(statement, options) # ms
-          if results.complete?
+
+          if results.present?
             columns = results.first.keys.map(&:to_s) if results.size > 0
             rows = results.map(&:values)
           else


### PR DESCRIPTION
When using blazer with the newest version of `google-cloud-bigquery`, running queries results in `undefined method 'complete?' for #<Google::Cloud::BigQuery::Data ...`.

This change attempts to fix the BigQuery adapter.