### PR TITLE
Add option to override app-wide csp settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,10 @@ if (!"AnomalyDetection" %in% installed.packages()) {
 
 Commit and deploy away. The first deploy may take a few minutes.
 
+## Content Security Policy
+
+If Blazer views are stuck with "Loading..." message there might be a problem with strict CSP settings in your app. This can be easily checked with Firefox or Chrome dev tools. If this is the case you can tell Blazer to override these settings for it's controllers with `override_csp: true` in `blazer.yml`.
+
 ## Upgrading
 
 ### 1.5

--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -24,6 +24,12 @@ module Blazer
       before_action Blazer.before_action.to_sym
     end
 
+    if Blazer.override_csp
+      after_action do
+        response.headers['Content-Security-Policy'] = "default-src 'self' https: 'unsafe-inline' 'unsafe-eval' data:"
+      end
+    end
+
     layout "blazer/application"
 
     private

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -39,6 +39,7 @@ module Blazer
     attr_accessor :images
     attr_accessor :query_viewable
     attr_accessor :query_editable
+    attr_accessor :override_csp
   end
   self.audit = true
   self.user_name = :name
@@ -46,6 +47,7 @@ module Blazer
   self.anomaly_checks = false
   self.async = false
   self.images = false
+  self.override_csp = false
 
   TIMEOUT_MESSAGE = "Query timed out :("
   TIMEOUT_ERRORS = [

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -22,6 +22,7 @@ module Blazer
       end
 
       Blazer.images = Blazer.settings["images"] || false
+      Blazer.override_csp = Blazer.settings["override_csp"] || false
     end
   end
 end

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -57,3 +57,6 @@ check_schedules:
   - "1 day"
   - "1 hour"
   - "5 minutes"
+
+# override app-wide csp for Blazer controllers
+override_csp: false


### PR DESCRIPTION
Hi @ankane,

this code adds Blazer option to override strict app csp which might block Blazer's functionality as discussed in #203 .

The csp headers are set directly through `response.headers` in `after_action`. So it should work with Rails < 5.2 also. However for Rails < 4 there would have to be branch which would use `after_filter` instead of `after_action`. But i don't know how much old Rails you want to support?

Have a nice day,
Masa331