### PR TITLE
Colors of pie chart for more then 20 records are missing - Issue Fixed

### DIFF
--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -108,7 +108,7 @@
     <% elsif chart_type == "line2" %>
       <%= line_chart @rows.group_by { |r| v = r[1]; (@boom[@columns[1]] || {})[v.to_s] || v }.each_with_index.map { |(name, v), i| {name: blazer_series_name(name), data: v.map { |v2| [v2[0], v2[2]] }, library: series_library[i]} }, chart_options %>
     <% elsif chart_type == "pie" %>
-      <%= pie_chart @rows.map { |r| [(@boom[@columns[0]] || {})[r[0].to_s] || r[0], r[1]] }, chart_options %>
+      <%= pie_chart @rows.map { |r| [(@boom[@columns[0]] || {})[r[0].to_s] || r[0], r[1]] }, chart_options.merge!(colors: @rows.map { "#" + "%06x" % (rand * 0xffffff)}) %>
     <% elsif chart_type == "bar" %>
       <%= column_chart (values.size - 1).times.map { |i| name = @columns[i + 1]; {name: blazer_series_name(name), data: @rows.first(20).map { |r| [(@boom[@columns[0]] || {})[r[0].to_s] || r[0], r[i + 1]] } } }, chart_options %>
     <% elsif chart_type == "bar2" %>


### PR DESCRIPTION
**Problem**
When we write some query and if the database returns more then 20 records then for the 21st and all upcoming records colors won't show up on the pie chart. 

**Solution**
I have added a small patch which will generate an array of random colors and passed it to the pie chart as chart options. The size/length of colors array will be equal to the number of records returned from the database in the query.
This solution will assign colors to every section of the pie chart and it won't miss any color. 

**Example**
Attached are the screenshots of the problems and a screenshot after the solution applied. 


Problem 1:
![problem number 1](https://user-images.githubusercontent.com/3322099/52949909-73f89b80-339f-11e9-8f3a-490a2f0a4f08.png)
Problem 2:
![problem number 2](https://user-images.githubusercontent.com/3322099/52949908-73f89b80-339f-11e9-8a01-5023e0ee96a1.png)
Solution:
![after solution applied](https://user-images.githubusercontent.com/3322099/52949910-73f89b80-339f-11e9-86f4-f3ba68209350.png)

