### PR TITLE
Idea: use liquid

### DIFF
--- a/app/controllers/blazer/dashboards_controller.rb
+++ b/app/controllers/blazer/dashboards_controller.rb
@@ -22,7 +22,7 @@ module Blazer
     def show
       @queries = @dashboard.dashboard_queries.order(:position).preload(:query).map(&:query)
       @queries.each do |query|
-        process_vars(query.statement, query.data_source)
+        query.statement = process_vars(query.statement, query.data_source)
       end
       @bind_vars ||= []
 
@@ -58,7 +58,7 @@ module Blazer
       @dashboard.queries.each do |query|
         data_source = Blazer.data_sources[query.data_source]
         statement = query.statement.dup
-        process_vars(statement, query.data_source)
+        statement = process_vars(statement, query.data_source)
         Blazer.transform_statement.call(data_source, statement) if Blazer.transform_statement
         data_source.clear_cache(statement)
       end

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -53,7 +53,7 @@ module Blazer
 
     def show
       @statement = @query.statement.dup
-      process_vars(@statement, @query.data_source)
+      @statement = process_vars(@statement, @query.data_source)
 
       @smart_vars = {}
       @sql_errors = []
@@ -68,12 +68,13 @@ module Blazer
     end
 
     def edit
+      @statement = params[:statement]
     end
 
     def run
       @statement = params[:statement]
       data_source = params[:data_source]
-      process_vars(@statement, data_source)
+      @statement = process_vars(@statement, data_source)
       @only_chart = params[:only_chart]
       @run_id = blazer_params[:run_id]
       @query = Query.find_by(id: params[:query_id]) if params[:query_id]
@@ -153,7 +154,7 @@ module Blazer
     def refresh
       data_source = Blazer.data_sources[@query.data_source]
       @statement = @query.statement.dup
-      process_vars(@statement, @query.data_source)
+      @statement = process_vars(@statement, @query.data_source)
       Blazer.transform_statement.call(data_source, @statement) if Blazer.transform_statement
       data_source.clear_cache(@statement)
       redirect_to query_path(@query, variable_params)

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -9,7 +9,7 @@
         <div class= "form-group">
           <%= f.hidden_field :statement %>
           <div id="editor-container">
-            <div id="editor" :style="{ height: editorHeight }"><%= @query.statement %></div>
+            <div id="editor" :style="{ height: editorHeight }" v-pre><%= @query.statement %></div>
           </div>
         </div>
         <div class="form-group text-right" style="margin-bottom: 8px;">

--- a/blazer.gemspec
+++ b/blazer.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 4.2"
   spec.add_dependency "chartkick"
   spec.add_dependency "safely_block", ">= 0.1.1"
+  spec.add_dependency "liquid"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -3,6 +3,7 @@ require "csv"
 require "yaml"
 require "chartkick"
 require "safely/core"
+require "liquid"
 
 # modules
 require "blazer/version"
@@ -115,9 +116,11 @@ module Blazer
   end
 
   def self.extract_vars(statement)
-    # strip commented out lines
-    # and regex {1} or {1,2}
-    statement.gsub(/\-\-.+/, "").gsub(/\/\*.+\*\//m, "").scan(/\{\w*?\}/i).map { |v| v[1...-1] }.reject { |v| /\A\d+(\,\d+)?\z/.match(v) || v.empty? }.uniq
+    template = Liquid::Template.parse(statement)
+    vars = template.root.nodelist.map do |node|
+      node.name.name if node.is_a? Liquid::Variable
+    end
+    vars.compact.uniq
   end
 
   def self.run_checks(schedule: nil)


### PR DESCRIPTION
This PR introduces liquid as main template engine for queries. Allows to write queries with null values, and also we could easily refactor the query below in the images to be IN ({{ occupation_id }} | join(', ') ), and then allow selectize to select multiple.

To do if idea accepted
- [ ] create migration to update `{occupation_id}` to  `{{ occupation_id }}` 

<img width="1106" alt="screenshot 2019-02-20 at 21 22 17" src="https://user-images.githubusercontent.com/2815199/53122017-d0052080-3555-11e9-8dd9-08bba63200b4.png">
<img width="1098" alt="screenshot 2019-02-20 at 21 22 53" src="https://user-images.githubusercontent.com/2815199/53122019-d1364d80-3555-11e9-9fc4-3de026ec1cff.png">
<img width="1108" alt="screenshot 2019-02-20 at 21 22 59" src="https://user-images.githubusercontent.com/2815199/53122021-d3001100-3555-11e9-96d8-b5ce287d304b.png">
