### PR TITLE
Bug Fix: StupidTable Plugin - fix issues with sorting integers and floats in the results table

### DIFF
--- a/app/assets/javascripts/blazer/application.js
+++ b/app/assets/javascripts/blazer/application.js
@@ -1,6 +1,7 @@
 //= require ./jquery
 //= require ./jquery-ujs
 //= require ./stupidtable
+//= require ./stupidtable-custom-settings
 //= require ./jquery.stickytableheaders
 //= require ./selectize
 //= require ./highlight.min

--- a/app/assets/javascripts/blazer/stupidtable-custom-settings.js
+++ b/app/assets/javascripts/blazer/stupidtable-custom-settings.js
@@ -1,0 +1,13 @@
+function removeCommas(string) {
+  return string.replace(/,/g, "")
+}
+
+// Remove commas for integers and floats to fix issues with sorting in the stupidtable plugin
+var stupidtableCustomSettings = {
+  "int": function(a, b) {
+    return parseInt(removeCommas(a), 10) - parseInt(removeCommas(b), 10);
+  },
+  "float": function(a, b) {
+    return parseFloat(removeCommas(a)) - parseFloat(removeCommas(b));
+  }
+}

--- a/app/assets/javascripts/blazer/stupidtable.js
+++ b/app/assets/javascripts/blazer/stupidtable.js
@@ -32,10 +32,10 @@
   $.fn.stupidtable.dir = {ASC: "asc", DESC: "desc"};
   $.fn.stupidtable.default_sort_fns = {
     "int": function(a, b) {
-      return parseInt(removeCommas(a), 10) - parseInt(removeCommas(b), 10);
+      return parseInt(a, 10) - parseInt(b, 10);
     },
     "float": function(a, b) {
-      return parseFloat(removeCommas(a)) - parseFloat(removeCommas(b));
+      return parseFloat(a) - parseFloat(b);
     },
     "string": function(a, b) {
       return a.toString().localeCompare(b.toString());
@@ -277,10 +277,5 @@
     });
     return th_index;
   };
-
-  // Remove commas from strings - used for parseInt and parseFloat when sorting
-  var removeCommas = function(string) {
-    return string.replace(/,/g, "")
-  }
 
 })(jQuery);

--- a/app/assets/javascripts/blazer/stupidtable.js
+++ b/app/assets/javascripts/blazer/stupidtable.js
@@ -32,10 +32,10 @@
   $.fn.stupidtable.dir = {ASC: "asc", DESC: "desc"};
   $.fn.stupidtable.default_sort_fns = {
     "int": function(a, b) {
-      return parseInt(a, 10) - parseInt(b, 10);
+      return parseInt(removeCommas(a), 10) - parseInt(removeCommas(b), 10);
     },
     "float": function(a, b) {
-      return parseFloat(a) - parseFloat(b);
+      return parseFloat(removeCommas(a)) - parseFloat(removeCommas(b));
     },
     "string": function(a, b) {
       return a.toString().localeCompare(b.toString());
@@ -277,5 +277,10 @@
     });
     return th_index;
   };
+
+  // Remove commas from strings - used for parseInt and parseFloat when sorting
+  var removeCommas = function(string) {
+    return string.replace(/,/g, "")
+  }
 
 })(jQuery);

--- a/app/views/blazer/dashboards/show.html.erb
+++ b/app/views/blazer/dashboards/show.html.erb
@@ -43,7 +43,7 @@
 
     runQuery(data, function (data) {
       $("#chart-<%= i %>").html(data)
-      $("#chart-<%= i %> table").stupidtable()
+      $("#chart-<%= i %> table").stupidtable(stupidtableCustomSettings)
     }, function (message) {
       $("#chart-<%= i %>").addClass("query-error").html(message)
     });

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -49,7 +49,7 @@
   <script>
     function showRun(data) {
       $("#results").html(data)
-      $("#results table").stupidtable().stickyTableHeaders({fixedOffset: 60})
+      $("#results table").stupidtable(stupidtableCustomSettings).stickyTableHeaders({fixedOffset: 60})
     }
 
     function showError(message) {


### PR DESCRIPTION
When clicking on the results table headers to sort, the integers and floats are not sorted correctly or as expected. 
- This is because the commas in the integers and floats, added by the plugin, break this functionality with `parseInt` and `parseFloat`.
- `removeCommas` method was added to remove the commas prior to using `parseInt` and `parseFloat`.

The video below reproduces the issue and shows the fix in action:

[Blazer PR | Bug Fix for results table sorting](https://watch.basilkhan.ca/watch/ywLm1cGS5XnMS5mQnLQzmk)