### PR TITLE
Hide Mastermind column on home page if user class does not exist

### DIFF
--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -32,7 +32,9 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th style="width: 20%; text-align: right;">Mastermind</th>
+        <% if Blazer.user_class %>
+          <th style="width: 20%; text-align: right;">Mastermind</th>
+        <% end%>
       </tr>
     </thead>
     <tbody class="list" v-cloak>
@@ -41,7 +43,9 @@
           <a :href="itemPath(query)" :class="{ dashboard: query.dashboard }">{{ query.name }}</a>
           <span class="vars">{{ query.vars }}</span>
         </td>
-        <td class="creator">{{ query.creator }}</td>
+        <% if Blazer.user_class %>
+          <td class="creator">{{ query.creator }}</td>
+        <% end %>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This is a simple fix that removes the Mastermind column on the home page when either the default or user defined `user_class` does not exist.

Below is a quick video showcasing the changes in the PR:

[![Play Video](https://play.vidyard.com/NRZAh2wNcB7YkNm8ibBM7P.jpg)
](https://watch.basilkhan.ca/watch/NRZAh2wNcB7YkNm8ibBM7P)
[Blazer PR | Hide Mastermind if user_class does not exist](https://watch.basilkhan.ca/watch/NRZAh2wNcB7YkNm8ibBM7P)

This PR is in reference to the `- hide mastermind if no user class` from Issue #24 