### PR TITLE
Add to dashboard from query page

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -200,17 +200,15 @@ module Blazer
     end
 
     def add_to_dashboards
-      dashboard_ids = params[:query][:dashboard_ids]
-      if dashboard_ids
+      dashboard_ids = params[:query] ? params[:query][:dashboard_ids] : []
+      if dashboard_ids && @query.persisted?
         dashboard_ids.each_with_index do |dashboard_id|
           @query.dashboard_queries.where(dashboard_id: dashboard_id).first_or_initialize do |dashboard_query|
             dashboard_query.position = Blazer::Dashboard.find(dashboard_id).query_ids.length
             dashboard_query.save!
           end
         end
-        if @query.persisted?
-          @query.dashboard_queries.where.not(dashboard_id: dashboard_ids).destroy_all
-        end
+        @query.dashboard_queries.where.not(dashboard_id: dashboard_ids).destroy_all
       end
       redirect_to query_path(@query)
     end

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -1,6 +1,7 @@
 module Blazer
   class QueriesController < BaseController
     before_action :set_query, only: [:show, :edit, :update, :destroy, :refresh, :add_to_dashboards]
+    before_action :set_dashboards, only: [:show]
     before_action :set_data_source, only: [:tables, :docs, :schema, :cancel]
 
     def home
@@ -322,10 +323,14 @@ module Blazer
 
       def set_query
         @query = Blazer::Query.find(params[:id].to_s.split("-").first)
-        @query_dashboards = Blazer::Dashboard.where.not(:queries => @query).order(:name)
+
         unless @query.viewable?(blazer_user)
           render_forbidden
         end
+      end
+
+      def set_dashboards
+        @dashboards = Blazer::Dashboard.order(:name)
       end
 
       def render_forbidden
@@ -334,10 +339,6 @@ module Blazer
 
       def query_params
         params.require(:query).permit(:name, :description, :statement, :data_source)
-      end
-
-      def dashboard_query_params
-        params.fetch(:query).permit(:dashboard_ids => [])
       end
 
       def blazer_params

--- a/app/views/blazer/queries/_add_to_dashboards.html.erb
+++ b/app/views/blazer/queries/_add_to_dashboards.html.erb
@@ -1,0 +1,28 @@
+<button type="button" class="btn btn-default pull-right" data-toggle="modal" data-target="#addToDashboards" style="margin-bottom: 10px;">Add to Dashboards</button>
+<!-- Modal -->
+<div class="modal fade" id="addToDashboards" tabindex="-1" role="dialog" aria-labelledby="addToDashboardsLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="addToDashboardsLabel">Add <%= query.name %> to Dashboards</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_tag(add_to_dashboards_query_path, method: 'patch', :class => 'form-group') do %>
+          <div class="modal-body">
+            <div class="list-group">
+            <% dashboards.each do |dashboard| %>
+              <label type="button" class="list-group-item">
+                <%= check_box_tag "query[dashboard_ids][]", dashboard.id, dashboard.query_ids.include?(@query.id) %>
+                  <span class="button-indecator"><%= dashboard.name %></span>
+                <%= link_to 'View Dashboard', dashboard_path(dashboard), :target => "_blank", :class => 'pull-right' %>
+              </label>
+            <% end %>
+          </div>
+            <%= submit_tag 'Add Query to Dashboards', :class => 'btn btn-primary btn-block'  %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/blazer/queries/_add_to_dashboards.html.erb
+++ b/app/views/blazer/queries/_add_to_dashboards.html.erb
@@ -8,7 +8,7 @@
         <h4 class="modal-title" id="addToDashboardsLabel">Add <%= query.name %> to Dashboards</h4>
       </div>
       <div class="modal-body">
-        <%= form_tag(add_to_dashboards_query_path, method: 'patch', :class => 'form-group') do %>
+        <%= form_tag(add_to_dashboards_query_path, method: 'post', :class => 'form-group') do %>
           <div class="modal-body">
             <div class="list-group">
             <% dashboards.each do |dashboard| %>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -59,24 +59,7 @@
       </div>
     </div>
   <% end %>
-  <%= form_tag(add_to_dashboards_query_path, method: 'patch') do %>
-      <div class="modal-body">
-          <div class="row">
-            <% Blazer::Dashboard.order(:name).each do |dashboard| %>
-              <div class="toggle lg col-md-4">
-                <label>
-                  <%= check_box_tag "query[dashboard_ids][]", dashboard.id, dashboard.query_ids.include?(@query.id) %>
-                  <span class="button-indecator"><%= dashboard.name %></span>
-                </label>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <div class="modal-footer">
-        <%= submit_tag 'Add Query to Dashboards', :class => 'btn btn-primary'  %>
-      </div>
-    <% end %>
-
+  
   <div id="results">
     <p class="text-muted" v-if="running">Loading...</p>
     <div id="results-html" v-if="!running" :class="{ 'query-error': error }"></div>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -59,6 +59,23 @@
       </div>
     </div>
   <% end %>
+  <%= form_tag(add_to_dashboards_query_path, method: 'patch') do %>
+      <div class="modal-body">
+          <div class="row">
+            <% Blazer::Dashboard.order(:name).each do |dashboard| %>
+              <div class="toggle lg col-md-4">
+                <label>
+                  <%= check_box_tag "query[dashboard_ids][]", dashboard.id, dashboard.query_ids.include?(@query.id) %>
+                  <span class="button-indecator"><%= dashboard.name %></span>
+                </label>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <div class="modal-footer">
+        <%= submit_tag 'Add Query to Dashboards', :class => 'btn btn-primary'  %>
+      </div>
+    <% end %>
 
   <div id="results">
     <p class="text-muted" v-if="running">Loading...</p>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -59,7 +59,7 @@
       </div>
     </div>
   <% end %>
-  
+ 
   <div id="results">
     <p class="text-muted" v-if="running">Loading...</p>
     <div id="results-html" v-if="!running" :class="{ 'query-error': error }"></div>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -59,7 +59,7 @@
       </div>
     </div>
   <% end %>
- 
+
   <div id="results">
     <p class="text-muted" v-if="running">Loading...</p>
     <div id="results-html" v-if="!running" :class="{ 'query-error': error }"></div>

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -23,6 +23,12 @@
 
 <div style="margin-bottom: 60px;"></div>
 
+<div class="row">
+  <div class="col-sm-12">
+    <%= render "add_to_dashboards", query: @query, dashboards: @dashboards %>
+  </div>
+</div>
+
 <% if @sql_errors.any? %>
   <div class="alert alert-danger">
     <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Blazer::Engine.routes.draw do
     post :run, on: :collection # err on the side of caution
     post :cancel, on: :collection
     post :refresh, on: :member
+    patch :add_to_dashboards, on: :member
     get :tables, on: :collection
     get :schema, on: :collection
     get :docs, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Blazer::Engine.routes.draw do
     post :run, on: :collection # err on the side of caution
     post :cancel, on: :collection
     post :refresh, on: :member
-    patch :add_to_dashboards, on: :member
+    post :add_to_dashboards, on: :member
     get :tables, on: :collection
     get :schema, on: :collection
     get :docs, on: :collection


### PR DESCRIPTION
This pull request is in reference to the `- add to dashboard from query page` in the issue #24.

This PR allows the user to add the queries to multiple dashboards right from the query show page. 
- When the user adds the query, this is appended to the end of the dashboard page (with position n+1, where n is the number of current queries on the dashboard)
- When the user removes the query, the query is deleted from the current position
- The dashboard_query positions are reset after removal of queries for each of the dashboards that were modified

Below is a quick video for an overview of the functionality:

[![Play Video](https://play.vidyard.com/YDFd6UCLJitWCGHUMhxWdD.jpg)
](https://watch.basilkhan.ca/watch/YDFd6UCLJitWCGHUMhxWdD)
[Blazer PR | Hide Mastermind if user_class does not exist](https://watch.basilkhan.ca/watch/YDFd6UCLJitWCGHUMhxWdD)

Below is the screenshot of the Add to Dashboard modal:
![image](https://user-images.githubusercontent.com/13711901/54939145-34712200-4efe-11e9-8ba1-6296478e566b.png)
