### PR TITLE
Adds option to configure mapbox access token in settings

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -29,7 +29,7 @@ module Blazer
     end
 
     def blazer_maps?
-      ENV["MAPBOX_ACCESS_TOKEN"].present?
+      Blazer.mapbox_access_token.present?
     end
 
     def blazer_js_var(name, value)

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -76,7 +76,7 @@
     <% if blazer_maps? && @markers.any? %>
       <div id="map" style="height: <%= @only_chart ? 300 : 500 %>px;"></div>
       <script>
-        L.mapbox.accessToken = '<%= ENV["MAPBOX_ACCESS_TOKEN"] %>';
+        L.mapbox.accessToken = '<%= Blazer.mapbox_access_token %>';
         var map = L.mapbox.map('map', 'ankane.ioo8nki0');
         <%= blazer_js_var "markers", @markers %>
         var featureLayer = L.mapbox.featureLayer().addTo(map);

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -52,6 +52,7 @@ module Blazer
     attr_accessor :query_editable
     attr_accessor :override_csp
     attr_accessor :slack_webhook_url
+    attr_accessor :mapbox_access_token
   end
   self.audit = true
   self.user_name = :name

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -26,6 +26,7 @@ module Blazer
       Blazer.images = Blazer.settings["images"] || false
       Blazer.override_csp = Blazer.settings["override_csp"] || false
       Blazer.slack_webhook_url = Blazer.settings["slack_webhook_url"] || ENV["BLAZER_SLACK_WEBHOOK_URL"]
+      Blazer.mapbox_access_token = Blazer.settings["mapbox_access_token"] || ENV["MAPBOX_ACCESS_TOKEN"]
     end
   end
 end

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -68,3 +68,6 @@ check_schedules:
 # enable forecasting
 # note: with trend, time series are sent to https://trendapi.org
 # forecasting: trend
+
+# enable map
+# mapbox_access_token: <%%= ENV["MAPBOX_ACCESS_TOKEN"] %>


### PR DESCRIPTION
Adds option to configure mapbox access token as a setting. 

This is useful in projects using rails secrets instead of setting environment variables.

This shouldn't break anything since it defaults the setting to the environment variable. 