### PR TITLE
Issue-246: State change slack notification should not depends on emails|

### DIFF
--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -68,8 +68,13 @@ module Blazer
 
       # do not notify on creation, except when not passing
       if (state_was != "new" || state != "passing") && state != state_was && emails.present?
-        Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
-        Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size, message, check_type)
+        if emails.present?
+          Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now
+        end
+
+        if slack_channels.present?
+          Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size, message, check_type)
+        end
       end
       save! if changed?
     end


### PR DESCRIPTION
Issue-246: State change slack notification should depends on channel presence instead of emails.
Issue - https://github.com/ankane/blazer/issues/246