### PR TITLE
add query params to csv filename

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -232,7 +232,6 @@ module Blazer
           end
         end
 
-        @filename = @query.name.parameterize if @query
         @min_width_types = @columns.each_with_index.select { |c, i| @first_row[i].is_a?(Time) || @first_row[i].is_a?(String) || @data_source.smart_columns[c] }.map(&:last)
 
         @boom = @result.boom if @result
@@ -262,9 +261,15 @@ module Blazer
             render layout: false
           end
           format.csv do
-            send_data csv_data(@columns, @rows, @data_source), type: "text/csv; charset=utf-8; header=present", disposition: "attachment; filename=\"#{@query.try(:name).try(:parameterize).presence || 'query'}.csv\""
+            send_data csv_data(@columns, @rows, @data_source), type: "text/csv; charset=utf-8; header=present", disposition: "attachment; filename=#{filename(@query, params[:query_params])}"
           end
         end
+      end
+
+      def filename(query, query_params)
+        base_name = query.try(:name).try(:parameterize).presence || 'query'
+
+        "#{base_name}-#{query_params}".parameterize + ".csv"
       end
 
       def set_queries(limit = nil)

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -14,7 +14,7 @@
         <%= link_to "Fork", new_query_path(variable_params.merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
 
         <% if !@error && @success %>
-          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv", forecast: params[:forecast]), params: {statement: @statement}, class: "btn btn-primary" %>
+          <%= button_to "Download", run_queries_path(query_id: @query.id, format: "csv", forecast: params[:forecast], query_params: variable_params), params: {statement: @statement}, class: "btn btn-primary" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Another implementation of https://github.com/ankane/blazer/pull/195

## Problem
Unfortunately previous patch doesn't work. When user push `Download` button it produces POST request with "ready to fire" query statement and already interpolated variables. So there are no way to get variables in case of csv response.

## Solution
Adding query params to csv request explicitly.

## Example
The example name of downloaded file:
`statistika-po-offeru-end_time-2019-07-30t20-59-59-00-00-offer_id-123-period-week-start_time-2019-06-30t21-00-00-00-00.csv`