### PR TITLE
Add expiration mechanism for AthenaAdapter's client_request_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,12 @@ data_sources:
     adapter: athena
     database: database
     output_location: s3://some-bucket/
+    client_request_token:
+      expiration_config:
+        - !ruby/sym sec: 0
 ```
+See [Time#change](https://apidock.com/rails/Time/change) for details on configuring an expiration window for [Athena's `client_request_token`](https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html#API_StartQueryExecution_RequestSyntax
+).
 
 ### Amazon Redshift
 


### PR DESCRIPTION
- Adds a truncated Timestamp to the digest inputs for client_request_token
- Timestamp truncation is configurabile via adapter settings (See Time#change)
- Default expiration is set to a 24 hour window

resolves #254