### PR TITLE
Support ActiveRecord config for SqlAdapter

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -11,7 +11,16 @@ module Blazer
             def self.name
               "Blazer::Connection::Adapter#{object_id}"
             end
-            establish_connection(data_source.settings["url"]) if data_source.settings["url"]
+            # If a URL is provided, it is ultimately parsed by URI::Generic which will raise
+            # a URI::InvalidURIError if URL includes special character (e.g. in a password)
+            # regardless if the special characters are properly escaped. In these situations
+            # the explicit hash configuration for the ActiveRecord adapter should be used
+            # instead as this method of configuration does properly handle special characters.
+            if data_source.settings["url"]
+              establish_connection(data_source.settings["url"])
+            elsif data_source.settings["active-record-config"]
+              establish_connection(data_source.settings["active-record-config"])
+            end
           end
       end
 


### PR DESCRIPTION
The current URL based approach does not handle special characters in passwords properly. The following uses Postgres to demonstrate the issue, but it is reproducible with any other adapter that is backed by an ActiveRecord connection.

---

Run a new Postgres container:

```
docker run --name oops -d -p 5433:5432 -e POSTGRES_USER=user -e POSTGRES_PASSWORD='aaaa}*bbbb)cc,dd' postgres
```

Note the presence of special characters in the password.


Next connect to the Postgres instance and create a new database:

```sql
create database test;
```

Connect to the `test` database and create a table:

```sql
create table animals (name varchar(255));

```


Execute the following to reproduce the issue:

```ruby
data_source = Blazer::DataSource.new(1, 'url' => 'postgres://user:aaaa}*bbbb)cc,dd@localhost:5433/test')
result = Blazer::RunStatement.new.perform(data_source, 'select * from animals')
```

A Rails console session from start to finish:

```
[1] pry(main)> data_source = Blazer::DataSource.new(1, 'url' => 'postgres://user:aaaa}*bbbb)cc,dd@localhost:5433/test')
=> #<Blazer::DataSource:0x0000560a4fa29a68 @id=1, @settings={"url"=>"postgres://user:aaaa}*bbbb)cc,dd@localhost:5433/test"}>
[2] pry(main)> result = Blazer::RunStatement.new.perform(data_source, 'select * from animals')
   (0.2ms)  BEGIN
  SQL (1.3ms)  INSERT INTO "blazer_audits" ("statement", "data_source", "created_at") VALUES ($1, $2, $3) RETURNING "id"  [["statement", "select * from animals"], ["data_source", "1"], ["created_at", "2019-12-05 05:07:02.473993"]]
   (16.3ms)  COMMIT
URI::InvalidURIError: bad URI(is not URI?): postgres://user:aaaa}*bbbb)cc,dd@localhost:5433/test
from /filtered/path/to/.rbenv/versions/2.6.3/lib/ruby/2.6.0/uri/rfc2396_parser.rb:177:in `split'
```

Using the change in this PR to directly configure the ActiveRecord adapter:

```ruby
data_source = Blazer::DataSource.new(1, 'active-record-config' => {
      'adapter' => 'postgresql',
      'username' => 'user',
      'password' => 'aaaa}*bbbb)cc,dd',
      'host' => 'localhost',
      'port' => 5433,
      'database' => 'test',
    })
result = Blazer::RunStatement.new.perform(data_source, 'select * from animals')
```

And the Rails console:

```
[2] pry(main)> data_source = Blazer::DataSource.new(1, 'active-record-config' => {
[2] pry(main)*     'adapter' => 'postgresql',      
[2] pry(main)*     'username' => 'user',      
[2] pry(main)*     'password' => 'aaaa}*bbbb)cc,dd',      
[2] pry(main)*     'host' => 'localhost',      
[2] pry(main)*     'port' => 5433,      
[2] pry(main)*     'database' => 'test',      
[2] pry(main)* })        
=> #<Blazer::DataSource:0x00005628ed5af610
 @id=1,
 @settings=
  {"active-record-config"=>
    {"adapter"=>"postgresql",
     "username"=>"user",
     "password"=>"aaaa}*bbbb)cc,dd",
     "host"=>"localhost",
     "port"=>5433,
     "database"=>"test"}}>
[3] pry(main)> result = Blazer::RunStatement.new.perform(data_source, 'select * from animals')
   (0.2ms)  BEGIN
  SQL (1.1ms)  INSERT INTO "blazer_audits" ("statement", "data_source", "created_at") VALUES ($1, $2, $3) RETURNING "id"  [["statement", "select * from animals"], ["data_source", "1"], ["created_at", "2019-12-05 05:11:56.870139"]]
   (12.8ms)  COMMIT
   (0.3ms)  BEGIN
   (0.4ms)  select * from animals /*blazer*/
   (0.2ms)  ROLLBACK
=> #<Blazer::Result:0x00005628f0970c88
 @cached_at=nil,
 @columns=["name"],
 @data_source=
  #<Blazer::DataSource:0x00005628ed5af610
   @adapter_instance=
    #<Blazer::Adapters::SqlAdapter:0x00005628f09011a8
     @connection_model=#<Class:0x00005628f0930ef8>(Table doesn't exist),
     @data_source=#<Blazer::DataSource:0x00005628ed5af610 ...>>,
   @cache={"mode"=>"off"},
   @id=1,
   @settings=
    {"active-record-config"=>
      {"adapter"=>"postgresql",
       "username"=>"user",
       "password"=>"aaaa}*bbbb)cc,dd",
       "host"=>"localhost",
       "port"=>5433,
       "database"=>"test"}}>,
 @error=nil,
 @just_cached=false,
 @rows=[]>
```