### PR TITLE
Support explicitly defining AWS credentials for Athena adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,18 @@ data_sources:
     output_location: s3://some-bucket/
 ```
 
+The AWS Access Key ID and Secret Access Key can optionally be set:
+
+```yml
+data_sources:
+  my_source:
+    adapter: athena
+    database: database
+    output_location: s3://some-bucket/
+    access_key_id: my-access-key-id
+    secret_access_key: my-secret-access-key
+```
+
 ### Amazon Redshift
 
 Add [activerecord4-redshift-adapter](https://github.com/aamine/activerecord4-redshift-adapter) or [activerecord5-redshift-adapter](https://github.com/ConsultingMD/activerecord5-redshift-adapter) to your Gemfile and set:

--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -118,11 +118,15 @@ module Blazer
       end
 
       def client
-        @client ||= Aws::Athena::Client.new
+        @client ||= Aws::Athena::Client.new(credentials: credentials)
       end
 
       def glue
-        @glue ||= Aws::Glue::Client.new
+        @glue ||= Aws::Glue::Client.new(credentials: credentials)
+      end
+
+      def credentials
+        @credentials ||= Aws::Credentials.new(settings['access_key_id'], settings['secret_access_key']) if settings.key?('access_key_id') && settings.key?('secret_access_key')
       end
     end
   end


### PR DESCRIPTION
Allows the credentials for the Athena adapter to be configured explicitly. If the settings are not provided, the AWS clients fallback to the normal process for resolving credentials that is currently used.