### PR TITLE
Poll Athena to determine when a query is being processed

### DIFF
--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -10,84 +10,30 @@ module Blazer
 
         begin
           resp =
-            client.start_query_execution(
-              query_string: statement,
-              # use token so we fetch cached results after query is run
-              client_request_token: Digest::MD5.hexdigest([statement,data_source.id].join("/")),
-              query_execution_context: {
-                database: database,
-              },
-              result_configuration: {
-                output_location: settings["output_location"]
-              }
-            )
+              client.start_query_execution(
+                  query_string: statement,
+                  # use token so we fetch cached results after query is run
+                  client_request_token: generate_client_request_token(statement),
+                  query_execution_context: {
+                      database: database,
+                  },
+                  result_configuration: {
+                      output_location: settings["output_location"]
+                  }
+              )
+
           query_execution_id = resp.query_execution_id
+          query_state = wait_for_query_results(query_execution_id)
 
-          timeout = data_source.timeout || 300
-          stop_at = Time.now + timeout
-          resp = nil
-
-          begin
-            resp = client.get_query_results(
-              query_execution_id: query_execution_id
-            )
-          rescue Aws::Athena::Errors::InvalidRequestException => e
-            unless e.message.start_with?("Query has not yet finished.")
-              raise e
-            end
-            if Time.now < stop_at
-              sleep(3)
-              retry
-            end
-          end
-
-          if resp && resp.result_set
-            column_info = resp.result_set.result_set_metadata.column_info
-            columns = column_info.map(&:name)
-            column_types = column_info.map(&:type)
-
-            untyped_rows = []
-
-            # paginated
-            resp.each do |page|
-              untyped_rows.concat page.result_set.rows.map { |r| r.data.map(&:var_char_value) }
-            end
-
-            utc = ActiveSupport::TimeZone['Etc/UTC']
-
-            rows = untyped_rows[1..-1] || []
-            rows = untyped_rows[0..-1] unless column_info.present?
-            column_types.each_with_index do |ct, i|
-              # TODO more column_types
-              case ct
-              when "timestamp"
-                rows.each do |row|
-                  row[i] = utc.parse(row[i])
-                end
-              when "date"
-                rows.each do |row|
-                  row[i] = Date.parse(row[i])
-                end
-              when "bigint"
-                rows.each do |row|
-                  row[i] = row[i].to_i
-                end
-              when "double"
-                rows.each do |row|
-                  row[i] = row[i].to_f
-                end
-              end
-            end
-          elsif resp
-            error = fetch_error(query_execution_id)
-          else
+          if query_state == 'SUCCEEDED'
+            columns, rows = *fetch_query_results(query_execution_id)
+          elsif processing?(query_state)
             error = Blazer::TIMEOUT_MESSAGE
+          else
+            error = fetch_error(query_execution_id)
           end
         rescue Aws::Athena::Errors::InvalidRequestException => e
           error = e.message
-          if error == "Query did not finish successfully. Final query state: FAILED"
-            error = fetch_error(query_execution_id)
-          end
         end
 
         [columns, rows, error]
@@ -105,10 +51,92 @@ module Blazer
         "SELECT * FROM {table} LIMIT 10"
       end
 
+      protected
+
+      # Allow this to be easily overridden for applications that might always want to execute a query
+      def generate_client_request_token(statement)
+        Digest::MD5.hexdigest([statement,data_source.id].join("/"))
+      end
+
       private
 
       def database
         @database ||= settings["database"] || "default"
+      end
+
+      def wait_for_query_results(query_execution_id)
+        timeout = data_source.timeout || 300
+        stop_at = Time.now + timeout
+
+        state = nil
+        wait = true
+
+        while wait
+          state = fetch_query_state(query_execution_id)
+
+          if processing?(state) && Time.now < stop_at
+            sleep(3)
+          else
+            wait = false
+          end
+        end
+
+        state
+      end
+
+      def processing?(state)
+        %w(QUEUED RUNNING).include?(state)
+      end
+
+      def fetch_query_results(query_execution_id)
+        resp = client.get_query_results(
+            query_execution_id: query_execution_id
+        )
+
+        column_info = resp.result_set.result_set_metadata.column_info
+        columns = column_info.map(&:name)
+        column_types = column_info.map(&:type)
+
+        untyped_rows = []
+
+        # paginated
+        resp.each do |page|
+          untyped_rows.concat page.result_set.rows.map { |r| r.data.map(&:var_char_value) }
+        end
+
+        utc = ActiveSupport::TimeZone['Etc/UTC']
+
+        rows = untyped_rows[1..-1] || []
+        rows = untyped_rows[0..-1] unless column_info.present?
+        column_types.each_with_index do |ct, i|
+          # TODO more column_types
+          case ct
+          when "timestamp"
+            rows.each do |row|
+              row[i] = utc.parse(row[i])
+            end
+          when "date"
+            rows.each do |row|
+              row[i] = Date.parse(row[i])
+            end
+          when "bigint"
+            rows.each do |row|
+              row[i] = row[i].to_i
+            end
+          when "double"
+            rows.each do |row|
+              row[i] = row[i].to_f
+            end
+          end
+        end
+
+        [columns, rows]
+      end
+
+      def fetch_query_state(query_execution_id)
+        client.get_query_execution(
+            query_execution_id: query_execution_id
+        ).query_execution.status.state
       end
 
       def fetch_error(query_execution_id)


### PR DESCRIPTION
The current implementation failed to retry queries that are in the `QUEUED` state prior to #256.

Instead of attempting to get the results of the query and retrying based on an error message which might change in the future, this PR checks the status of the query via the AWS APIs to determine when it has succeeded and the results can be retrieved.

This also includes a minor change to perform the creation of the request token in a separate method that can be easily monkey patched for applications that always want to execute a query. Currently if someone needs this behavior, they must duplicate the entirety of the `run_statement` method to support this.

**EDIT**: Note this was originally based on a version of Blazer prior to #256. The change to poll for the status of the query is still an improvement to the general functionality of this adapter that should be considered.