### PR TITLE
Fix search by non-ASCII characters

### DIFF
--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -71,7 +71,7 @@
   }
 
   var prepareQuery = function (str) {
-    return str.toLowerCase().replace(/\W+/g, "")
+    return str.toLowerCase()
   }
 
   var app = new Vue({


### PR DESCRIPTION
The `\W` character class in JavaScript RegEx is really only useful with simple ASCII encoding.

### before
![](https://i.gyazo.com/c4ddabe4451962265c739457c2ccd618.gif)

### after
![](https://i.gyazo.com/3c1835dbd8c5180a429388158cccb749.gif)