### PR TITLE
Fix mapbox API deprecation

### DIFF
--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -80,7 +80,9 @@
         <%= blazer_js_var "mapboxAccessToken", Blazer.mapbox_access_token %>
         <%= blazer_js_var "markers", @markers %>
         L.mapbox.accessToken = mapboxAccessToken;
-        var map = L.mapbox.map('map', 'mapbox.streets');
+        var map = L.mapbox.map('map')
+          .setView([40, -74.50], 9)
+          .addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
         var featureLayer = L.mapbox.featureLayer().addTo(map);
         var geojson = [];
         for (var i = 0; i < markers.length; i++) {


### PR DESCRIPTION
When making requests to mapbox they are now all failing due to a deprecation. They are replying with a "410 Gone":

Example request:
https://a.tiles.mapbox.com/v4/mapbox.streets/3/4/2.png?access_token=thetoken

The response:

```
{"message":"Classic styles are no longer supported; see https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4 for more information"}
```

https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4

# Before the change
![Screen Shot 2020-05-20 at 12 52 03 PM](https://user-images.githubusercontent.com/170654/82474469-1c147d00-9a99-11ea-8b75-3483dd704862.png)

# After the change
![Screen Shot 2020-05-20 at 12 52 36 PM](https://user-images.githubusercontent.com/170654/82474478-1f0f6d80-9a99-11ea-8b6e-5185452baa46.png)
