### PR TITLE
Show the description on the Queries home page

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -270,7 +270,7 @@ module Blazer
       end
 
       def set_queries(limit = nil)
-        @queries = Blazer::Query.named.select(:id, :name, :creator_id, :statement)
+        @queries = Blazer::Query.named.select(:id, :name, :description, :creator_id, :statement)
         @queries = @queries.includes(:creator) if Blazer.user_class
 
         if blazer_user && params[:filter] == "mine"
@@ -292,6 +292,7 @@ module Blazer
             {
               id: q.id,
               name: q.name,
+              description: q.description,
               creator: blazer_user && q.try(:creator) == blazer_user ? "You" : q.try(:creator).try(Blazer.user_name),
               vars: q.variables.join(", "),
               to_param: q.to_param

--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -32,6 +32,7 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Description</th>
         <% if Blazer.user_class %>
           <th style="width: 20%; text-align: right;">Mastermind</th>
         <% end%>
@@ -42,6 +43,9 @@
         <td>
           <a :href="itemPath(query)" :class="{ dashboard: query.dashboard }">{{ query.name }}</a>
           <span class="vars">{{ query.vars }}</span>
+        </td>
+        <td class="text-muted">
+          {{ query.description }}
         </td>
         <% if Blazer.user_class %>
           <td class="creator">{{ query.creator }}</td>


### PR DESCRIPTION
Hello again open source hero ankane! 👋.

I was surprised to see that the queries index page does not show the query description. We have a number of queries that benefit from a few extra details that are provided in the description. This small PR adds the description to the query table for extra details.

For example:

<img width="734" alt="image" src="https://user-images.githubusercontent.com/438465/89089790-acf2b900-d364-11ea-9df4-a2291ddfab4a.png">

