### PR TITLE
Add row_limit settings

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -278,6 +278,7 @@ module Blazer
 
         respond_to do |format|
           format.html do
+            @row_limit ||= Blazer.row_limit if Blazer.row_limit
             render layout: false
           end
           format.csv do

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -59,6 +59,7 @@ module Blazer
     attr_accessor :override_csp
     attr_accessor :slack_webhook_url
     attr_accessor :mapbox_access_token
+    attr_accessor :row_limit
   end
   self.audit = true
   self.user_name = :name

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -25,6 +25,7 @@ module Blazer
       Blazer.from_email = Blazer.settings["from_email"] if Blazer.settings["from_email"]
       Blazer.before_action = Blazer.settings["before_action_method"] if Blazer.settings["before_action_method"]
       Blazer.check_schedules = Blazer.settings["check_schedules"] if Blazer.settings.key?("check_schedules")
+      Blazer.row_limit = Blazer.settings["row_limit"] if Blazer.settings["row_limit"]
       Blazer.cache ||= Rails.cache
 
       Blazer.anomaly_checks = Blazer.settings["anomaly_checks"] || false

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -77,3 +77,7 @@ check_schedules:
 #   url: <%%= ENV["BLAZER_UPLOADS_URL"] %>
 #   schema: uploads
 #   data_source: main
+
+# limit of row count in HTML view.
+# default is unlimited
+# row_limit: 5000


### PR DESCRIPTION
I think this is useful in cases where the execution of a query doesn't time out, but the number of results is so large that it takes a long time to render.

I actually tested this with a simple query that returned 100,000 rows of results.
What would normally take more than 20 seconds to render was reduced to less than 5 seconds.

#270 