### PR TITLE
Make naming of BaseController explicit

### DIFF
--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -1,5 +1,5 @@
 module Blazer
-  class ChecksController < BaseController
+  class ChecksController < Blazer::BaseController
     before_action :set_check, only: [:edit, :update, :destroy, :run]
 
     def index

--- a/app/controllers/blazer/dashboards_controller.rb
+++ b/app/controllers/blazer/dashboards_controller.rb
@@ -1,5 +1,5 @@
 module Blazer
-  class DashboardsController < BaseController
+  class DashboardsController < Blazer::BaseController
     before_action :set_dashboard, only: [:show, :edit, :update, :destroy, :refresh]
 
     def new

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -1,5 +1,5 @@
 module Blazer
-  class QueriesController < BaseController
+  class QueriesController < Blazer::BaseController
     before_action :set_query, only: [:show, :edit, :update, :destroy, :refresh]
     before_action :set_data_source, only: [:tables, :docs, :schema, :cancel]
 

--- a/app/controllers/blazer/uploads_controller.rb
+++ b/app/controllers/blazer/uploads_controller.rb
@@ -1,5 +1,5 @@
 module Blazer
-  class UploadsController < BaseController
+  class UploadsController < Blazer::BaseController
     before_action :ensure_uploads
     before_action :set_upload, only: [:show, :edit, :update, :destroy]
 


### PR DESCRIPTION
In my application I have a `BaseController` just like Blazer has. It seems that depending on non-deterministic loading order sometimes Blazer tries to inherit from my `BaseController` instead of the actual Blazer-`BaseController`.

This PR fixes this by making the inheritance of `Blazer::BaseController` explicit.