### PR TITLE
Implement completion of table names and columns

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -1,5 +1,7 @@
 module Blazer
   module BaseHelper
+    include CompletionHelper
+
     def blazer_title(title = nil)
       if title
         content_for(:title) { title }

--- a/app/helpers/blazer/completion_helper.rb
+++ b/app/helpers/blazer/completion_helper.rb
@@ -1,0 +1,31 @@
+module Blazer
+  module CompletionHelper
+    BLAZER_COMPLETION_COLUMN_SCORE = 1001
+    BLAZER_COMPLETION_COLUMN_META = 'column_name'
+    BLAZER_COMPLETION_TABLE_SCORE = 1000
+    BLAZER_COMPLETION_TABLE_META = 'table_name'
+
+    def extract_tables_and_columns(schema)
+      schema.map do |schema_entry|
+        [schema_entry[:table], schema_entry[:columns]]
+      end
+    end
+
+    def blazer_table_name_completion_source
+      extract_tables_and_columns(Blazer.data_sources['main'].schema).collect do |entry|
+        {
+          value: entry.first,
+          columns: entry.last.map do |column|
+            {
+              value: column[:name],
+              score: BLAZER_COMPLETION_COLUMN_SCORE,
+              meta: BLAZER_COMPLETION_COLUMN_META
+            }
+          end,
+          score: BLAZER_COMPLETION_TABLE_SCORE,
+          meta: BLAZER_COMPLETION_TABLE_META
+        }
+      end.to_json
+    end
+  end
+end

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -70,6 +70,27 @@
   <%= blazer_js_var "params", variable_params(@query) %>
   <%= blazer_js_var "previewStatement", Hash[Blazer.data_sources.map { |k, v| [k, (v.preview_statement rescue "")] }] %>
 
+  const extractTableNameFromEditor = function(content, pos) {
+    const lines = content.split('\n');
+    const currentRow = lines[pos.row];
+    const previousTokens = currentRow.slice(pos.column - 2, pos.column);
+    const columnSeparatorPosition = previousTokens.indexOf('.');
+    if (columnSeparatorPosition === -1) {
+        return null;
+    }
+    const absolutTableNamePosition = ((pos.column) - previousTokens.length) + columnSeparatorPosition;
+
+    let tableName = "";
+    for (index = absolutTableNamePosition - 1; index > 0; index--) {
+        if (currentRow[index] === ' ') {
+            break;
+        } else {
+            tableName += currentRow[index];
+        }
+    }
+    return tableName.split('').reverse().join('');
+  }
+
   var app = new Vue({
     el: "#app",
     data: {
@@ -151,13 +172,36 @@
         editor.setTheme("ace/theme/twilight")
         editor.getSession().setMode("ace/mode/sql")
         editor.setOptions({
-          enableBasicAutocompletion: false,
+          enableBasicAutocompletion: true,
           enableSnippets: false,
-          enableLiveAutocompletion: false,
+          enableLiveAutocompletion: true,
           highlightActiveLine: false,
           fontSize: 12,
           minLines: 10
-        })
+        });
+
+        const tableNames = JSON.parse("<%== j blazer_table_name_completion_source %>");
+        editor.completers.push({
+            getCompletions: function(editor, session, pos, prefix, callback) {
+                callback(null, tableNames);
+            }
+        });
+
+        editor.completers.push({
+            getCompletions: function(editor, session, pos, prefix, callback) {
+                const tableName = extractTableNameFromEditor(editor.getValue(), pos);
+                if (tableName !== null) {
+                    for (index = 0; index < tableNames.length; index++) {
+                        const entry = tableNames[index];
+                        if (entry.value === tableName) {
+                            callback(null, entry.columns);
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
         editor.renderer.setShowGutter(true)
         editor.renderer.setPrintMarginColumn(false)
         editor.renderer.setPadding(10)


### PR DESCRIPTION
This pull request implements autocompletion of table names as well as columns within the ace editor used by blazer.
This also enables the autocompletion feature of the ace editor.

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/35100156/111877919-e173bd80-89a5-11eb-9aee-723be59e86e3.mov
</details>
<details>
<summary>After</summary>

https://user-images.githubusercontent.com/35100156/111877460-d324a200-89a3-11eb-9f99-c00ca5433b62.mov

</details>

Currently, column names are only autocompleted when being prefix with:

`table_name.`

Completion either starts after the first typed character or can be triggered with `<C-SPACE>`


As I am not sure why autocompletion was turned off in the first place, I'm sorry if this intrudes or hinders other features of blazer.

_This was initially implemented for https://github.com/renuo/blazer/pull/3_
