### PR TITLE
Add column type timestamp with time zone to athena adapter

### DIFF
--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -60,7 +60,7 @@ module Blazer
             column_types.each_with_index do |ct, i|
               # TODO more column_types
               case ct
-              when "timestamp"
+              when "timestamp", "timestamp with time zone"
                 rows.each do |row|
                   row[i] = utc.parse(row[i])
                 end


### PR DESCRIPTION
Previously when running an Athena query with e.g. `from_iso8601_timestamp()`, it would not be automatically rendered as a linechart, because the column type was not recognized and parsed as timestamp.

The subsequent call to `ActiveSupport::TimeZone['Etc/UTC'].parse` will convert the value to UTC when the string value contains a different timezone than UTC:

```
irb(main):001:0> ActiveSupport::TimeZone['Etc/UTC'].parse('2021-05-05 09:00:00 CEST')
=> Wed, 05 May 2021 07:00:00 UTC +00:00
```

Or would you prefer to keep the time zone? Then I could change it to use e.g. `DateTime.parse`.