### PR TITLE
Adds viewport meta tag for dashboard

### DIFF
--- a/app/views/layouts/blazer/application.html.erb
+++ b/app/views/layouts/blazer/application.html.erb
@@ -7,6 +7,7 @@
     <%= favicon_link_tag "blazer/favicon.png" %>
     <%= stylesheet_link_tag "blazer/application" %>
     <%= javascript_include_tag "blazer/application" %>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
       <%= blazer_js_var "rootPath", root_path %>
     </script>


### PR DESCRIPTION
[Viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) sets viewport width to devise screen size. This gives a much better browsing experience for dashboard on mobile devices. 

Before on moto G4
![Screenshot 2021-06-04 at 12 23 36 PM](https://user-images.githubusercontent.com/10867145/120758932-1072e780-c530-11eb-9909-85f0a0b45d2a.png)

After on moto G4
![Screenshot 2021-06-04 at 12 24 07 PM](https://user-images.githubusercontent.com/10867145/120758989-1ec10380-c530-11eb-912a-ccf746129cd3.png)

Before on ipad
![Screenshot 2021-06-04 at 12 25 02 PM](https://user-images.githubusercontent.com/10867145/120759035-2e404c80-c530-11eb-8221-7c5e3f6ed62f.png)

After on ipad
![Screenshot 2021-06-04 at 12 24 35 PM](https://user-images.githubusercontent.com/10867145/120759057-35fff100-c530-11eb-8f44-e68e47d3aa37.png)

before on iphone 5
![Screenshot 2021-06-04 at 12 25 22 PM](https://user-images.githubusercontent.com/10867145/120759115-4adc8480-c530-11eb-82bf-37cceb255f38.png)

After on iphone 5
![Screenshot 2021-06-04 at 12 25 45 PM](https://user-images.githubusercontent.com/10867145/120759136-5039cf00-c530-11eb-83fa-d97505aa8863.png)


