### PR TITLE
Return all results from BigQuery run_statement

### DIFF
--- a/lib/blazer/adapters/bigquery_adapter.rb
+++ b/lib/blazer/adapters/bigquery_adapter.rb
@@ -13,7 +13,7 @@ module Blazer
           # code is for backward compatibility
           if !results.respond_to?(:complete?) || results.complete?
             columns = results.first.keys.map(&:to_s) if results.size > 0
-            rows = results.map(&:values)
+            rows = results.all.map(&:values)
           else
             error = Blazer::TIMEOUT_MESSAGE
           end


### PR DESCRIPTION
Within a downstream application, we were noticing that the results returned by bigquery for very large tables was less than expected via their web console. We found that this was because the [`Google::Cloud::Bigquery::Data`](https://googleapis.dev/ruby/google-cloud-bigquery/latest/Google/Cloud/Bigquery/Data.html) class by default returns its results in "pages", where each page may only contain a portion of the full result. Using the [`all`](https://googleapis.dev/ruby/google-cloud-bigquery/latest/Google/Cloud/Bigquery/Data.html#all-instance_method) method returns an enumerable over all the results, matching expectations of the returned result.

The `all` method exists for all documented versions of the google-cloud-bigquery gem.