### PR TITLE
Stop establishing the connection as part of `preview_statement`

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -208,7 +208,7 @@ module Blazer
       end
 
       def sqlserver?
-        ["SQLServer", "tinytds", "mssql"].include?(adapter_name)
+        data_source.settings["url"].starts_with?("jdbc:sqlserver://")
       end
 
       def snowflake?


### PR DESCRIPTION
### Problem
`#preview_statement` is called in the `queries/_form` partial.

That has the side effect of needing to establish a connection for all sources that use the `SqlAdapter` as part of the `sqlserver?` method.

This causes the `queries/new` and `queries/edit` to become slow when one has a lot of data sources. 

### Solution
Use the url to determine if the connection is SQL Server or not