### PR TITLE
Do not attempt to coerce a value when NULL

### DIFF
--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -62,19 +62,19 @@ module Blazer
               case ct
               when "timestamp"
                 rows.each do |row|
-                  row[i] = utc.parse(row[i])
+                  row[i] &&= utc.parse(row[i])
                 end
               when "date"
                 rows.each do |row|
-                  row[i] = Date.parse(row[i])
+                  row[i] &&= Date.parse(row[i])
                 end
               when "bigint"
                 rows.each do |row|
-                  row[i] = row[i].to_i
+                  row[i] &&= row[i].to_i
                 end
               when "double"
                 rows.each do |row|
-                  row[i] = row[i].to_f
+                  row[i] &&= row[i].to_f
                 end
               end
             end


### PR DESCRIPTION
Previously, an Athena query such as

    SELECT CAST(NULL AS timestamp)

resulted in an "no implicit conversion of nil into String" error due
to the attempt to parse `nil` as time.

Also do not set numeric values to 0 or 0.0 when NULL.