### PR TITLE
Fix multiple channel support for Slack apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ BLAZER_SLACK_WEBHOOK_URL=https://hooks.slack.com/...
 
 Name the webhook “Blazer” and add a cool icon.
 
+If you want to send more than 1 channel, [create an app](https://api.slack.com/apps?new_app=1), create one webhook per channel
+you want to send to, and use the following syntax in blazer.yml
+```yaml
+slack_webhook_url:
+  a_channel: https://hooks.slack.com/...
+  another_channel: https://hooks.slack.com/...
+```   
+
 ## Authentication
 
 Don’t forget to protect the dashboard in production.

--- a/lib/blazer/slack_notifier.rb
+++ b/lib/blazer/slack_notifier.rb
@@ -49,7 +49,12 @@ module Blazer
         ]
       }
 
-      post(Blazer.slack_webhook_url, payload)
+      url = if Blazer.slack_webhook_url.is_a?(Hash)
+              Blazer.slack_webhook_url[channel]
+            else
+              Blazer.slack_webhook_url
+            end
+      post(url, payload) if url.present?
     end
 
     # https://api.slack.com/docs/message-formatting#how_to_escape_characters

--- a/lib/blazer/slack_notifier.rb
+++ b/lib/blazer/slack_notifier.rb
@@ -23,7 +23,12 @@ module Blazer
           ]
         }
 
-        post(Blazer.slack_webhook_url, payload)
+        url = if Blazer.slack_webhook_url.is_a?(Hash)
+                Blazer.slack_webhook_url[channel]
+              else
+                Blazer.slack_webhook_url
+              end
+        post(url, payload) if url.present?
       end
     end
 

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -55,6 +55,11 @@ audit: true
 
 # webhook for Slack
 # slack_webhook_url: <%%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
+#
+# or for more than one channel
+# slack_webhook_url:
+#   a_channel: https://hooks.slack.com/...
+#   another_channel: https://hooks.slack.com/...
 
 check_schedules:
   - "1 day"


### PR DESCRIPTION
With the way slack apps work now, one of the limitations of the slack integration is that the webhook is specific to a single channel, so you need to configure slack apps with one webhook per channel you can post on.

Right now, specifying one or more channels in a check configuration does nothing with such an integration, because slack will post to the channel that's associated with the webhook, not the channel specified in the payload.

This PR tweaks the configuration so the slack_webhook_url config can either take a string (for the current behavior) or a mapping of slack channel -> webhook URL in form of a hash.

When sending the webhook, the new code will check whether a url is configured for this channel before sending it.