### PR TITLE
Check stv_inflight for query PID for redshift cancel

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -111,7 +111,8 @@ module Blazer
         if postgresql?
           select_all("SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND query LIKE ?", ["%,run_id:#{run_id}%"])
         elsif redshift?
-          first_row = select_all("SELECT pid FROM stv_recents WHERE status = 'Running' AND query LIKE ?", ["%,run_id:#{run_id}%"]).first
+          run_text = "%,run_id:#{run_id}%"
+          first_row = select_all("SELECT pid FROM stv_recents WHERE status = 'Running' AND query LIKE ? UNION SELECT pid FROM stv_inflight WHERE text LIKE ?", [run_text, run_text]).first
           if first_row
             select_all("CANCEL #{first_row["pid"].to_i}")
           end


### PR DESCRIPTION
For some setups of Redshift, we are finding that getting the currently running query is more reliable to search the [`STV_INFLIGHT`](https://docs.aws.amazon.com/redshift/latest/dg/r_STV_INFLIGHT.html) over [`STV_RECENTS`](https://docs.aws.amazon.com/redshift/latest/dg/r_STV_RECENTS.html). In these setups, the query will show up in the former table and not in the latter table until after the query has finished. I'm not totally certain why that is, but suspect it's something to do with the nature of cluster nodes, but the whole thing is opaque and I couldn't find any good concrete information on googling.

The join here shouldn't add too much additional overhead, but I don't have a heavily used Redshift cluster to verify against.