### PR TITLE
Added support for ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,12 +716,15 @@ data_sources:
 
 ### ClickHouse
 
-Add [ClickHouse Ruby driver](https://github.com/shlima/click_house) OR [Clickhouse::Activerecord](https://github.com/PNixx/clickhouse-activerecord) to your Gemfile and set:
+Add [ClickHouse Ruby driver](https://github.com/shlima/click_house) to your Gemfile and set:
 ```yml
 data_sources:
   my_source:
     adapter: clickhouse
     url: http://user:password@hostname:8123/database
+
+    # optional settings
+    ssl_verify: true # false by default
 ```
 
 ### Druid

--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ data_sources:
 - [Apache Ignite](#apache-ignite)
 - [Apache Spark](#apache-spark)
 - [Cassandra](#cassandra)
+- [ClickHouse](#clickhouse)
 - [Druid](#druid)
 - [Elasticsearch](#elasticsearch)
 - [Google BigQuery](#google-bigquery)
@@ -711,6 +712,16 @@ Add [cassandra-driver](https://github.com/datastax/ruby-driver) to your Gemfile 
 data_sources:
   my_source:
     url: cassandra://user:password@hostname:9042/keyspace
+```
+
+### ClickHouse
+
+Add [ClickHouse Ruby driver](https://github.com/shlima/click_house) to your Gemfile and set:
+```yml
+data_sources:
+  my_source:
+    adapter: clickhouse
+    url: http://user:password@hostname:8123/database
 ```
 
 ### Druid

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ data_sources:
 
 ### ClickHouse
 
-Add [ClickHouse Ruby driver](https://github.com/shlima/click_house) to your Gemfile and set:
+Add [ClickHouse Ruby driver](https://github.com/shlima/click_house) OR [Clickhouse::Activerecord](https://github.com/PNixx/clickhouse-activerecord) to your Gemfile and set:
 ```yml
 data_sources:
   my_source:

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -15,6 +15,7 @@ require "blazer/adapters/base_adapter"
 require "blazer/adapters/athena_adapter"
 require "blazer/adapters/bigquery_adapter"
 require "blazer/adapters/cassandra_adapter"
+require "blazer/adapters/clickhouse_adapter"
 require "blazer/adapters/drill_adapter"
 require "blazer/adapters/druid_adapter"
 require "blazer/adapters/elasticsearch_adapter"
@@ -254,6 +255,7 @@ end
 Blazer.register_adapter "athena", Blazer::Adapters::AthenaAdapter
 Blazer.register_adapter "bigquery", Blazer::Adapters::BigQueryAdapter
 Blazer.register_adapter "cassandra", Blazer::Adapters::CassandraAdapter
+Blazer.register_adapter "clickhouse", Blazer::Adapters::ClickhouseAdapter
 Blazer.register_adapter "drill", Blazer::Adapters::DrillAdapter
 Blazer.register_adapter "druid", Blazer::Adapters::DruidAdapter
 Blazer.register_adapter "elasticsearch", Blazer::Adapters::ElasticsearchAdapter

--- a/lib/blazer/adapters/clickhouse_adapter.rb
+++ b/lib/blazer/adapters/clickhouse_adapter.rb
@@ -1,14 +1,55 @@
 module Blazer
   module Adapters
     class ClickhouseAdapter < BaseAdapter
+      SUPPORTED_DRIVERS_MAPPING = {
+        "click_house" => ClickHouseDriver,
+        "clickhouse-activerecord" => ClickhouseActiverecordDriver
+      }.freeze
+
+      delegate :tables, to: :driver
+
+      # Wrapper for ClickHouse Ruby driver (https://github.com/shlima/click_house)
+      class ClickHouseDriver
+        delegate :tables, to: :connection
+
+        def initialize(config)
+          @config = ClickHouse::Config.new(**config)
+        end
+
+        def connection
+          @connection ||= ClickHouse::Connection.new(@config)
+        end
+
+        def execute(statement, format)
+          connection.post(query: { query: statement, default_format: format }).body
+        end
+      end
+
+      # Wrapper for Clickhouse::Activerecord driver (https://github.com/PNixx/clickhouse-activerecord)
+      class ClickhouseActiverecordDriver
+        delegate :tables, to: :connection
+
+        def initialize(config)
+          @config = config
+        end
+
+        def connection
+          @connection ||= ActiveRecord::Base.clickhouse_connection(@config)
+        end
+
+        def execute(statement, format)
+          body = connection.do_execute(statement, format: format)
+          format.in?(%w[CSV CSVWithNames]) ? CSV.parse(body) : body
+        end
+      end
+
       def run_statement(statement, _comment)
         columns = []
         rows = []
         error = nil
 
         begin
-          response = connection.post(query: { query: statement, default_format: "CSVWithNames" })
-          rows = response.body
+          rows = driver.execute(statement, "CSVWithNames")
           columns = rows.shift
         rescue => e
           error = e.message
@@ -17,23 +58,18 @@ module Blazer
         [columns, rows, error]
       end
 
-      def tables
-        connection.tables
-      end
-
       def schema
         statement = <<-SQL
           SELECT table, name, type
           FROM system.columns
-          WHERE database = '#{connection.config.database}'
+          WHERE database = '#{config[:database]}'
           ORDER BY table, position
         SQL
 
-        response = connection.post(query: { query: statement, default_format: "CSV" })
-        response.body
-                .group_by { |row| row[0] }
-                .transform_values { |columns| columns.map { |c| { name: c[1], data_type: c[2] } } }
-                .map { |table, columns| { schema: "public", table: table, columns: columns } }
+        rows = driver.execute(statement, "CSV")
+        rows.group_by { |row| row[0] }
+            .transform_values { |columns| columns.map { |c| { name: c[1], data_type: c[2] } } }
+            .map { |table, columns| { schema: "public", table: table, columns: columns } }
       end
 
       def preview_statement
@@ -41,19 +77,24 @@ module Blazer
       end
 
       def explain(statement)
-        connection.explain(statement)
+        driver.execute("EXPLAIN #{statement.gsub(/\A(\s*EXPLAIN)/io, '')}", "TSV")
       end
 
       protected
 
-      def connection
-        @connection ||= ClickHouse::Connection.new(config)
+      def driver
+        @driver ||= begin
+          driver = SUPPORTED_DRIVERS_MAPPING.keys.find { |driver| installed?(driver) }
+          raise Blazer::Error, "ClickHouse driver not installed!" unless driver
+
+          SUPPORTED_DRIVERS_MAPPING[driver].new(config)
+        end
       end
 
       def config
         @config ||= begin
           uri = URI.parse(settings["url"])
-          options = {
+          {
             scheme: uri.scheme,
             host: uri.host,
             port: uri.port,
@@ -61,9 +102,14 @@ module Blazer
             password: uri.password,
             database: uri.path.split("/").last
           }.compact
-
-          ClickHouse::Config.new(**options)
         end
+      end
+
+      def installed?(driver_name)
+        Gem::Specification.find_by_name(driver_name)
+        true
+      rescue Gem::LoadError
+        false
       end
     end
   end

--- a/lib/blazer/adapters/clickhouse_adapter.rb
+++ b/lib/blazer/adapters/clickhouse_adapter.rb
@@ -14,8 +14,8 @@ module Blazer
             date_time_columns = result.meta
                                       .select { |column| column["type"].in?(DATE_TIME_TYPES) }
                                       .map { |column| column["name"] }
-            columns = result.data.first.keys
-            rows = result.data.map { |row| convert_time_columns(row, date_time_columns).values }
+            columns = result.first.keys
+            rows = result.map { |row| convert_time_columns(row, date_time_columns).values }
           end
         rescue => e
           error = e.message

--- a/lib/blazer/adapters/clickhouse_adapter.rb
+++ b/lib/blazer/adapters/clickhouse_adapter.rb
@@ -1,0 +1,70 @@
+module Blazer
+  module Adapters
+    class ClickhouseAdapter < BaseAdapter
+      def run_statement(statement, _comment)
+        columns = []
+        rows = []
+        error = nil
+
+        begin
+          response = connection.post(query: { query: statement, default_format: "CSVWithNames" })
+          rows = response.body
+          columns = rows.shift
+        rescue => e
+          error = e.message
+        end
+
+        [columns, rows, error]
+      end
+
+      def tables
+        connection.tables
+      end
+
+      def schema
+        statement = <<-SQL
+          SELECT table, name, type
+          FROM system.columns
+          WHERE database = '#{connection.config.database}'
+          ORDER BY table, position
+        SQL
+
+        response = connection.post(query: { query: statement, default_format: "CSV" })
+        response.body
+                .group_by { |row| row[0] }
+                .transform_values { |columns| columns.map { |c| { name: c[1], data_type: c[2] } } }
+                .map { |table, columns| { schema: "public", table: table, columns: columns } }
+      end
+
+      def preview_statement
+        "SELECT * FROM {table} LIMIT 10"
+      end
+
+      def explain(statement)
+        connection.explain(statement)
+      end
+
+      protected
+
+      def connection
+        @connection ||= ClickHouse::Connection.new(config)
+      end
+
+      def config
+        @config ||= begin
+          uri = URI.parse(settings["url"])
+          options = {
+            scheme: uri.scheme,
+            host: uri.host,
+            port: uri.port,
+            username: uri.user,
+            password: uri.password,
+            database: uri.path.split("/").last
+          }.compact
+
+          ClickHouse::Config.new(**options)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[ClickHouse](https://clickhouse.com/) adapter implementation (resolves https://github.com/ankane/blazer/issues/378).

Requires `click_house` Ruby driver to interact with clickhouse-server via HTTP interface.

Adapter methods:
 - run_statement
 - tables
 - schema
 - preview_statement
 - explain
 
Readme instructions also added.