### PR TITLE
[Mapbox] Prevent truncation in the middle of a HTML tag + add logic for better truncation based on key and value length

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -264,10 +264,23 @@ module Blazer
               @rows.select do |r|
                 r[lat_index] && r[lon_index]
               end.map do |r|
+                rows_limit = 6
+                row_length_limit = 70
+                key_length_limit = 20
+                limit = 140
+                title = @columns.zip(r).reject { |k, v| keys.include?(k) }[0...rows_limit].collect do |k, v|
+                          # Mapbox.js does sanitization with https://github.com/mapbox/sanitize-caja
+                          # but we should do it here as well
+                          k = ERB::Util.html_escape(k)
+                          v = ERB::Util.html_escape(v)
+                          new_key_lenght = (key_length_limit + v.length) > row_length_limit ? key_length_limit : row_length_limit - v.length
+
+                          k = k.truncate(new_key_lenght)
+                          v = v.truncate(row_length_limit - k.length)
+                          "<strong>#{k}:</strong> #{v}"
+                        end.join("<br />")
                 {
-                  # Mapbox.js does sanitization with https://github.com/mapbox/sanitize-caja
-                  # but we should do it here as well
-                  title: r.each_with_index.map { |v, i| i == lat_index || i == lon_index ? nil : "<strong>#{ERB::Util.html_escape(@columns[i])}:</strong> #{ERB::Util.html_escape(v)}" }.compact.join("<br />").truncate(140),
+                  title: title,
                   latitude: r[lat_index],
                   longitude: r[lon_index]
                 }

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -265,8 +265,8 @@ module Blazer
                 r[lat_index] && r[lon_index]
               end.map do |r|
                 rows_limit = 6
-                row_length_limit = 70
                 key_length_limit = 20
+                row_length_limit = 70 # key + value limit
                 title = @columns.zip(r).reject { |k, v| keys.include?(k) }[0...rows_limit].collect do |k, v|
                           # Mapbox.js does sanitization with https://github.com/mapbox/sanitize-caja
                           # but we should do it here as well

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -267,7 +267,6 @@ module Blazer
                 rows_limit = 6
                 row_length_limit = 70
                 key_length_limit = 20
-                limit = 140
                 title = @columns.zip(r).reject { |k, v| keys.include?(k) }[0...rows_limit].collect do |k, v|
                           # Mapbox.js does sanitization with https://github.com/mapbox/sanitize-caja
                           # but we should do it here as well


### PR DESCRIPTION
## Fixes/improvements
 - As in below screenshot, when the length of the content is such that there's a HTML `<br />` or `<strong>` tag at the 140 character position in the string, then the tag ends up being truncated to result in opening angle brackets appearing
 - IMO I don't think `<strong>` or `<br />` tags should count towards the char limit
 - previously a large column name could result in the content being needlessly truncated when the column can be instead
 - if there's 1 long row, that now won't prevent the proceeding columns being shown
   - now the earlier long row will instead be truncated

Eg
```sql
SELECT
  2.2913515 AS longitude,
  48.85391 AS latitude,
  "Eiffel Tower" AS name,
  "Paris" AS city,
  "France" AS country,
  "French" AS language_name,
  "300 m, 324 m to tip" AS height,
  "The Eiffel Tower is a wrought-iron lattice tower on the Champ de Mars in Paris, France. It is named after the engineer Gustave Eiffel, whose company designed and built the tower." AS full_wiki_description
```

## Before:

![image](https://user-images.githubusercontent.com/4098222/154861585-a1b8755e-f5b1-4f27-90db-cf8302ee6aa6.png)

## After:

![image](https://user-images.githubusercontent.com/4098222/154861610-323c72ca-8fae-4a0c-9205-4682a698d4fb.png)

### With 1 long row

![image](https://user-images.githubusercontent.com/4098222/154861911-3e032da9-2a31-4c78-8ad9-cde0d1fa0153.png)


These limits could be made configurable later on if there was a need but I think these are reasonable limits