### PR TITLE
Enable adapter tests and disable broken Elasticsearch tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,5 @@ jobs:
     - uses: ankane/setup-mysql@v1
       with:
         database: blazer_test
+    - uses: ankane/setup-elasticsearch@v1
     - run: bundle exec rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,4 @@ jobs:
     - uses: ankane/setup-mysql@v1
       with:
         database: blazer_test
-    - uses: ankane/setup-elasticsearch@v1
     - run: bundle exec rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,7 @@ jobs:
     - uses: ankane/setup-postgres@v1
       with:
         database: blazer_test
+    - uses: ankane/setup-mysql@v1
+      with:
+        database: blazer_test
     - run: bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,6 @@ require "rake/testtask"
 task default: :test
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.pattern = "test/*_test.rb"
+  t.pattern = "test/**/*_test.rb"
   t.warning = false # mail gem
 end

--- a/test/adapters/elasticsearch_test.rb
+++ b/test/adapters/elasticsearch_test.rb
@@ -2,10 +2,12 @@ require_relative "../test_helper"
 
 class ElasticsearchTest < ActionDispatch::IntegrationTest
   def test_run
+    # skip "broken"
     run_query "SELECT 1", data_source: "elasticsearch"
   end
 
   def test_tables
+    # skip "broken"
     get blazer.tables_queries_path(data_source: "elasticsearch")
     assert_response :success
     assert_kind_of Array, JSON.parse(response.body)

--- a/test/adapters/elasticsearch_test.rb
+++ b/test/adapters/elasticsearch_test.rb
@@ -2,12 +2,12 @@ require_relative "../test_helper"
 
 class ElasticsearchTest < ActionDispatch::IntegrationTest
   def test_run
-    # skip "broken"
+    skip "broken"
     run_query "SELECT 1", data_source: "elasticsearch"
   end
 
   def test_tables
-    # skip "broken"
+    skip "broken"
     get blazer.tables_queries_path(data_source: "elasticsearch")
     assert_response :success
     assert_kind_of Array, JSON.parse(response.body)


### PR DESCRIPTION
 - include tests by updating pattern
 - add MySQL to be included during tests
 - skip broken Elasticsearch tests

I also tried adding [ankane/setup-elasticsearch](https://github.com/ankane/setup-elasticsearch) but that failed with the following error:

```ruby
The client is unable to verify that the server is Elasticsearch. Some functionality may not be compatible if the server is running an unsupported product.
The client is unable to verify that the server is Elasticsearch. Some functionality may not be compatible if the server is running an unsupported product.
.......E

Error:
ElasticsearchTest#test_tables:
Elasticsearch::UnsupportedProductError: The client noticed that the server is not Elasticsearch and we do not support this unknown product.
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/elasticsearch-8.0.0/lib/elasticsearch.rb:1[15](https://github.com/cianmce/blazer/runs/5305254255?check_suite_focus=true#step:7:15):in `verify_with_version_or_header'
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/elasticsearch-8.0.0/lib/elasticsearch.rb:104:in `verify_elasticsearch'
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/elasticsearch-8.0.0/lib/elasticsearch.rb:70:in `method_missing'
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/elasticsearch-api-8.0.0/lib/elasticsearch/api/namespace/common.rb:38:in `perform_request'
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/elasticsearch-api-8.0.0/lib/elasticsearch/api/actions/cat/indices.rb:60:in `indices'
    /home/runner/work/blazer/blazer/lib/blazer/adapters/elasticsearch_adapter.rb:30:in `tables'
    /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/forwardable.rb:238:in `tables'
    /home/runner/work/blazer/blazer/app/controllers/blazer/queries_controller.rb:[20](https://github.com/cianmce/blazer/runs/5305254255?check_suite_focus=true#step:7:20)0:in `tables'
    /home/runner/work/blazer/blazer/vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.2.2/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
```
