### PR TITLE
Add basic JSON and YAML rendering in pre tag

### DIFF
--- a/app/helpers/blazer/base_helper.rb
+++ b/app/helpers/blazer/base_helper.rb
@@ -24,7 +24,21 @@ module Blazer
           link_to value, value, target: "_blank"
         end
       else
-        value
+        if key.include?("json")
+          begin
+            content_tag(:pre, JSON.pretty_generate(JSON.parse(value)))
+          rescue JSON::ParserError
+            content_tag(:pre, value)
+          end
+        elsif key.include?("yaml")
+          begin
+            content_tag(:pre, YAML.dump(YAML.load(value)))
+          rescue Psych::SyntaxError
+            content_tag(:pre, value)
+          end
+        else
+          value
+        end
       end
     end
 


### PR DESCRIPTION
Following on from idea: https://github.com/ankane/blazer/issues/388

If a column name contains `JSON` or `YAML` then do the appropriate parsing and pretty-printing, if parsing fails then just return the value in a `pre` tag

We could also add config to explicitly enable or disable this, similar to what is done with image

<hr>

Sample SQL using MySQL data source
```sql
SELECT "test: [1,2,3,4]\ntest2: key2" AS sample_yaml, '{"test": [1,2,3,4], "test2": "key2"}' AS sample_json, "test_content" AS sample_text
UNION
SELECT "invaid: yaml\nobject", '{"invalid": "json"', "more_text"
```

![image](https://user-images.githubusercontent.com/4098222/155504752-4602099b-705f-4dfb-a7c5-ea11b340885b.png)

