### PR TITLE
Fixed undefined "prepared_statements?" method for Rails < 7.0

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -193,7 +193,7 @@ module Blazer
       def parameter_binding
         if postgresql? || sqlite?
           :numeric
-        elsif mysql? && connection_model.connection.prepared_statements?
+        elsif mysql? && connection_model.connection.prepared_statements
           # Active Record silently ignores binds with MySQL when prepared statements are disabled
           :positional
         elsif sqlserver?


### PR DESCRIPTION
At the beginning I would like to thank you for this gem and all your work.

Looks like changes introduced in Blazer 2.6 has broken apps using MySQL and Rails < 7.0. 

The following exception is raised:
```
NoMethodError - undefined method `prepared_statements?' for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x000000010e905b78>
```

From what I researched `prepared_statements?` was added as an alias to `prepared_statements` in Rails 7 https://github.com/rails/rails/commit/da26910fbcfa3aa23ebc1474b43b048b78b60e4c