### PR TITLE
Add sharing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,47 @@ cache:
 
 Of course, you can force a refresh at any time.
 
+### Sharing (optional)
+
+You can generate sharing urls for queries. You can download up-to-date results for each query in CSV directly.
+
+This is useful for scripts or for automatic importing into spreadsheets.
+
+There are 2 steps necessary for setting up sharing:
+
+1. Configuring an API key
+2. Make the sharing endpoint accessible in your routes
+
+First configure an API key in `blazer.yml`:
+
+```yml
+sharing:
+  api_key: 'secret'
+```
+
+Alternatively you can set the `BLAZER_DOWNLOAD_API_KEY` ENV var which blazer uses by default.
+
+Now routes: we assume you have secured blazer so you will need to expose a new route outside of the mount.
+
+The default path for shares is `/blazer_share`. You can change this in `blazer.yml`:
+
+```yml
+sharing:
+  path: /another_path
+```
+
+This config is only so that blazer can generate the correct url.
+
+Now add this route to your `routes.rb`:
+
+```ruby
+  get Blazer.sharing.route_path, to: Blazer.sharing.to_controller if Blazer.sharing.enabled?
+```
+
+Now restart your server and each query page will have a `share` button which will open up a modal that allows you to copy sharing urls.
+
+Each url has a unique token based on a hash of the query's id and the API key, so the token can't be reused for other queries.
+
 ## Charts
 
 Blazer will automatically generate charts based on the types of the columns returned in your query.

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -78,6 +78,14 @@ module Blazer
     def edit
     end
 
+    def share
+      if params[:token] && params[:query_id] && params[:token] == Blazer.sharing.query_token(params[:query_id])
+        run
+      else
+        render_forbidden
+      end
+    end
+
     def run
       @query = Query.find_by(id: params[:query_id]) if params[:query_id]
 
@@ -87,7 +95,8 @@ module Blazer
       data_source ||= params[:data_source]
       @data_source = Blazer.data_sources[data_source]
 
-      @statement = Blazer::Statement.new(params[:statement], @data_source)
+      sql_statement = params[:statement] || @query.statement
+      @statement = Blazer::Statement.new(sql_statement, @data_source)
       # before process_vars
       @cohort_analysis = @statement.cohort_analysis?
 

--- a/app/views/blazer/queries/_sharing_modal.html.erb
+++ b/app/views/blazer/queries/_sharing_modal.html.erb
@@ -20,10 +20,6 @@
           <input type="text" class="form-control" id="googleShare" readonly value='=IMPORTDATA("<%= Blazer.sharing.url_for(7, request.url, format: 'csv') %>")'>
         </div>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/blazer/queries/_sharing_modal.html.erb
+++ b/app/views/blazer/queries/_sharing_modal.html.erb
@@ -17,7 +17,7 @@
 
         <div class="form-group">
           <label for="csvShare">Google sheets</label>
-          <input type="text" class="form-control" id="csvShare" readonly value='=IMPORTDATA("<%= Blazer.sharing.url_for(7, request.url, format: 'csv') %>")'>
+          <input type="text" class="form-control" id="googleShare" readonly value='=IMPORTDATA("<%= Blazer.sharing.url_for(7, request.url, format: 'csv') %>")'>
         </div>
       </div>
       <div class="modal-footer">

--- a/app/views/blazer/queries/_sharing_modal.html.erb
+++ b/app/views/blazer/queries/_sharing_modal.html.erb
@@ -1,0 +1,29 @@
+<div class="modal fade" id="sharingModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Sharing</h4>
+      </div>
+      <div class="modal-body">
+        Below are some shareable links to this query. Copy and share them.
+
+        Anyone with these urls can access the results of this query!
+
+        <div class="form-group">
+          <label for="csvShare">CSV</label>
+          <input type="text" class="form-control" id="csvShare" readonly value="<%= Blazer.sharing.url_for(7, request.url, format: 'csv') %>">
+        </div>
+
+        <div class="form-group">
+          <label for="csvShare">Google sheets</label>
+          <input type="text" class="form-control" id="csvShare" readonly value='=IMPORTDATA("<%= Blazer.sharing.url_for(7, request.url, format: 'csv') %>")'>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -10,17 +10,21 @@
 <div class="topbar">
   <div class="container">
     <div class="row" style="padding-top: 13px;">
-      <div class="col-sm-9">
+      <div class="col-sm-8">
         <%= render partial: "blazer/nav" %>
         <h3 style="line-height: 34px; display: inline; margin-left: 5px;">
           <%= @query.name %>
         </h3>
       </div>
-      <div class="col-sm-3 text-right">
+      <div class="col-sm-4 text-right">
         <%= link_to "Edit", edit_query_path(@query, params: variable_params(@query)), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
         <%= link_to "Fork", new_query_path(params: variable_params(@query).merge(fork_query_id: @query.id, data_source: @query.data_source, name: @query.name)), class: "btn btn-info" %>
 
         <% if !@error && @success %>
+          <% if Blazer.sharing.enabled? %>
+              <span class='btn btn-success' data-toggle="modal" data-target="#sharingModal">Share</span>
+          <% end %>
+
           <%= button_to "Download", run_queries_path(format: "csv"), params: run_data, class: "btn btn-primary" %>
         <% end %>
       </div>
@@ -77,4 +81,8 @@
       hljs.highlightBlock(document.getElementById("code"));
     }
   </script>
+<% end %>
+
+<% if Blazer.sharing.enabled? %>
+  <%= render(partial: 'sharing_modal') %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Blazer::Engine.routes.draw do
     get :tables, on: :collection
     get :schema, on: :collection
     get :docs, on: :collection
+    get Blazer.sharing.route_path, to: 'queries#share', as: :share
   end
 
   resources :checks, except: [:show] do

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -12,6 +12,7 @@ require "blazer/version"
 require "blazer/data_source"
 require "blazer/result"
 require "blazer/run_statement"
+require "blazer/sharing"
 require "blazer/statement"
 
 # adapters
@@ -132,6 +133,13 @@ module Blazer
         ds[id] = Blazer::DataSource.new(id, s)
       end
       ds
+    end
+  end
+
+  def self.sharing
+    @sharing ||= begin
+      sharing_settings = settings["sharing"] || {}
+      Blazer::Sharing.new(**sharing_settings.symbolize_keys)
     end
   end
 

--- a/lib/blazer/sharing.rb
+++ b/lib/blazer/sharing.rb
@@ -1,0 +1,36 @@
+module Blazer
+  class Sharing
+    attr_accessor :api_key, :path
+
+    def initialize(api_key: ENV.fetch('BLAZER_DOWNLOAD_API_KEY', nil), path: '/blazer_share')
+      @api_key = api_key
+      @path = path.sub(/\/$/, '') # Strip trailing /
+    end
+
+    def route_path
+      @route_path ||= "#{path}/:token/:query_id"
+    end
+
+    def to_controller
+      'blazer/queries#share'
+    end
+
+    def query_token(query_id)
+      Digest::SHA1.hexdigest("#{query_id}-#{ENV.fetch('BLAZER_DOWNLOAD_API_KEY')}")
+    end
+
+    def enabled?
+      api_key.present?
+    end
+
+    def share_path(query_id, format: nil)
+      "#{path}/#{query_token(query_id)}/#{query_id}#{".#{format}" if format}"
+    end
+
+    def url_for(query_id, current_url, format: 'csv')
+      url = URI.parse(current_url)
+      url.path = share_path(query_id, format: format)
+      url.to_s
+    end
+  end
+end

--- a/test/queries_test.rb
+++ b/test/queries_test.rb
@@ -108,12 +108,12 @@ class QueriesTest < ActionDispatch::IntegrationTest
   end
 
   def test_share
-    ENV['BLAZER_DOWNLOAD_API_KEY'] = '123'
+    Blazer.sharing.api_key = "123"
     query = create_query
     get blazer.query_share_path(query_id: query.id, token: Digest::SHA1.hexdigest("#{query.id}-123"), format: 'csv')
     assert_response :success
     assert_match query.name, response.body
-    ENV.delete('BLAZER_DOWNLOAD_API_KEY')
+    Blazer.sharing.api_key = nil
   end
 
   def test_url

--- a/test/queries_test.rb
+++ b/test/queries_test.rb
@@ -107,6 +107,15 @@ class QueriesTest < ActionDispatch::IntegrationTest
     assert_equal "id,city\n1,Chicago\n", response.body
   end
 
+  def test_share
+    ENV['BLAZER_DOWNLOAD_API_KEY'] = '123'
+    query = create_query
+    get blazer.query_share_path(query_id: query.id, token: Digest::SHA1.hexdigest("#{query.id}-123"), format: 'csv')
+    assert_response :success
+    assert_match query.name, response.body
+    ENV.delete('BLAZER_DOWNLOAD_API_KEY')
+  end
+
   def test_url
     run_query "SELECT 'http://localhost:3000/'"
     assert_match %{<a target="_blank" href="http://localhost:3000/">http://localhost:3000/</a>}, response.body


### PR DESCRIPTION
We are looking at replacing, amongst other things, Heroku dataclips with Blazer. The thing that we use a lot with dataclips is the sharing feature: it allows a developer to write a SQL query, they then share the CSV url with a non-technical person who can then import that into whatever tool that supports CSVs. Every time they re-download the CSV it is up-to-date with the query. When importing into Google sheets it results in an always up-to-date sheet, great all around.

In this PR I have added the feature to Blazer. 

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/27729/183280128-92fb2a7f-9ea8-4e26-ab83-0d3e3af78d13.png">

In building I realised I can still extract it and sort of patch it in, but I'd rather contribute back. I've tried to keep close to the overall design and style.

The only change I needed to make to the `QueriesController` that might be a good change regardless of this feature is the following:

From:

```ruby
@statement = Blazer::Statement.new(params[:statement], @data_source)
```

To:

```ruby
sql_statement = params[:statement] || @query.statement
@statement = Blazer::Statement.new(sql_statement, @data_source)
```