### PR TITLE
Add support for displaying GeoJSON columns in a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,14 @@ SELECT gender, COUNT(*) AS pie FROM users GROUP BY 1
 
 ### Maps
 
-Columns named `latitude` and `longitude` or `lat` and `lon` or `lat` and `lng` - [Example](https://blazer.dokkuapp.com/queries/15-map)
+Columns named `latitude` and `longitude` or `lat` and `lon` or `lat` and `lng` or GeoJSON in a column with `geojson` in the name - [Example](https://blazer.dokkuapp.com/queries/15-map)
 
 ```sql
 SELECT name, latitude, longitude FROM cities
+```
+
+```sql
+SELECT name, ST_AsGeoJSON(the_geom) AS geojson FROM counties
 ```
 
 To enable, get an access token from [Mapbox](https://www.mapbox.com/) and set `ENV["MAPBOX_ACCESS_TOKEN"]`.

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -275,6 +275,20 @@ module Blazer
           end
         end
 
+        @geojson = []
+        geojson_index = @columns.each_index.select {|i| @columns[i].include?("geojson") }.first
+        if geojson_index
+          @geojson = @rows.map do |r|
+            geometry = JSON.parse(r[geojson_index]) rescue nil
+            next unless geometry
+
+            {
+              title: r.each_with_index.map { |v, i| i == geojson_index ? nil : "<strong>#{ERB::Util.html_escape(@columns[i])}:</strong> #{ERB::Util.html_escape(v)}" }.compact.join("<br />").truncate(140),
+              geometry: geometry,
+            }
+          end.compact
+        end
+
         render_cohort_analysis if @cohort_analysis && !@error
 
         respond_to do |format|

--- a/app/views/blazer/queries/docs.html.erb
+++ b/app/views/blazer/queries/docs.html.erb
@@ -118,7 +118,7 @@
     <tr>
       <td>Map</td>
       <td>
-        Named <code>latitude</code> and <code>longitude</code>, or <code>lat</code> and <code>lon</code>, or <code>lat</code> and <code>lng</code>
+        Named <code>latitude</code> and <code>longitude</code>, or <code>lat</code> and <code>lon</code>, or <code>lat</code> and <code>lng</code> or GeoJSON in a column containing <code>geojson</code>.
         <% if !blazer_maps? %>
           <br />
           <strong>Needs configured</strong>

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -129,7 +129,6 @@
             }
           });
         }
-        console.log(features);
         featureLayer.setGeoJSON(features);
         map.fitBounds(featureLayer.getBounds());
       </script>

--- a/app/views/blazer/queries/run.html.erb
+++ b/app/views/blazer/queries/run.html.erb
@@ -105,6 +105,34 @@
         featureLayer.setGeoJSON(geojson);
         map.fitBounds(featureLayer.getBounds());
       </script>
+    <% elsif blazer_maps? && @geojson.any? %>
+      <% map_id = SecureRandom.hex %>
+      <%= content_tag :div, nil, id: map_id, style: "height: #{@only_chart ? 300 : 500}px;" %>
+      <script>
+        <%= blazer_js_var "mapboxAccessToken", Blazer.mapbox_access_token %>
+        <%= blazer_js_var "geojson", @geojson %>
+        <%= blazer_js_var "mapId", map_id %>
+        L.mapbox.accessToken = mapboxAccessToken;
+        var map = L.mapbox.map(mapId)
+          .addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
+        var featureLayer = L.mapbox.featureLayer().addTo(map);
+        var features = [];
+        for (var i = 0; i < geojson.length; i++) {
+          var geometry = geojson[i].geometry;
+          var title = geojson[i].title;
+
+          features.push({
+            type: 'Feature',
+            geometry: geometry,
+            properties: {
+              description: title,
+            }
+          });
+        }
+        console.log(features);
+        featureLayer.setGeoJSON(features);
+        map.fitBounds(featureLayer.getBounds());
+      </script>
     <% elsif chart_type == "line" %>
       <% chart_data = @columns[1..-1].each_with_index.map{ |k, i| {name: blazer_series_name(k), data: @rows.map{ |r| [r[0], r[i + 1]] }, library: series_library[i]} } %>
       <%= line_chart chart_data, **chart_options %>


### PR DESCRIPTION
This adds support for rendering columns containing GeoJSON in a map. This works especially well with PostGIS where you can generate GeoJSON from geometry columns with `ST_AsGeoJSON`. e.g.,

```sql
SELECT id, name, ST_AsGeoJSON(the_geom) AS the_geom_geojson FROM table
```

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/100/192039595-c52a393e-d0c3-4781-9998-0fe382773f44.png">

This works great for visualizing data in tables that contain geographic data, but also for experimenting with and viewing queries with arbitrary data and/or geographic calculations. e.g.,

```sql
SELECT id, name, ST_AsGeoJSON(ST_Envelope(the_geom::geometry)) AS the_geom_geojson
FROM counties
WHERE state_abbreviation = 'OH'
  AND name ILIKE 'C%';
```

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/100/192040647-28d89472-9bdb-40f4-9601-908ed7a65c70.png">

 The implementation was derived from markers.