### PR TITLE
Making pageSize and setLimit constants equal

### DIFF
--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -122,7 +122,7 @@
         // hack to get to update
         this.updateCounter
 
-        var pageSize = 200
+        var pageSize = 1000
         var q, i
 
         if (this.searchTerm.length > 0) {


### PR DESCRIPTION
I'm not sure if pagination is intended to work here, but in its absence, the pageSize should equal the setLimit constant so that all items are shown.