### PR TITLE
Send CSRF token in POST body when cancelling queries

### DIFF
--- a/app/assets/javascripts/blazer/queries.js
+++ b/app/assets/javascripts/blazer/queries.js
@@ -106,7 +106,8 @@ function cancelServerQuery(query) {
   var path = Routes.cancel_queries_path()
   var data = {run_id: query.run_id, data_source: query.data_source}
   if (navigator.sendBeacon) {
-    navigator.sendBeacon(path + "?" + $.param(csrfProtect(data)))
+    var json = JSON.stringify(csrfProtect(data));
+    navigator.sendBeacon(path, new Blob([json], {type: "application/json"}))
   } else {
     // TODO make sync
     $.post(path, data)


### PR DESCRIPTION
The fact that this token was sent in the query string came up in a pentest, since query strings may be logged/cached in some systems.

[`navigator.sendBeacon()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) accepts various things as the 'data' argument but we need a Blob here to specify the correct MIME type, otherwise sendBeacon defaults to `text/plain`. Some versions of Chrome didn't allow other MIME types here for a period, but this has been [fixed](https://bugs.chromium.org/p/chromium/issues/detail?id=724929).

Verified this works by with querying for `select pg_sleep(5);` and immediately navigating away, logs show the query got cancelled as expected (`SELECT pg_cancel_backend(pid) ...`).