### PR TITLE
Better description

### DIFF
--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -34,7 +34,7 @@
 <% end %>
 
 <% if @query.description.present? %>
-  <p style="white-space: pre-line;"><%= @query.description %></p>
+  <pre style="white-space: pre-line;"><%= @query.description %></pre>
 <% end %>
 
 <%= render partial: "blazer/variables", locals: {action: query_path(@query)} %>


### PR DESCRIPTION
When making a blazer the new lines are not preserved in the description making it hard to understand the goal of the blazer

If I have more than 4 lines of description it is all collapsed to 2 lines in a row. 

Most people skip this

Having it spaced out like this github description is one solution that will make it much clearer for people what a blazer does