### PR TITLE
Add `blazer_base_controller` load hook

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -129,5 +129,7 @@ module Blazer
     def default_url_options
       {}
     end
+
+    ActiveSupport.run_load_hooks(:blazer_base_controller, self)
   end
 end


### PR DESCRIPTION
Added hook for easy customization of controllers.

Related Issues: #279