### PR TITLE
Cohorts: Remove zeros, show appropriate number of columns

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -104,7 +104,7 @@ module Blazer
       @run_id = blazer_params[:run_id]
 
       run_cohort_analysis if @cohort_analysis
-
+      
       query_running = !@run_id.nil?
 
       if query_running

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -104,7 +104,7 @@ module Blazer
       @run_id = blazer_params[:run_id]
 
       run_cohort_analysis if @cohort_analysis
-      
+
       query_running = !@run_id.nil?
 
       if query_running

--- a/app/views/blazer/queries/_cohorts.html.erb
+++ b/app/views/blazer/queries/_cohorts.html.erb
@@ -5,12 +5,13 @@
   </p>
 <% end %>
 <% if @rows.any? %>
+  <% cohort_period_cols = @rows.map(&:length).max - 2 %>
   <div class="results-container">
     <table class="table results-table">
       <thead>
         <tr>
           <th style="min-width: 100px;">Cohort</th>
-          <% 12.times do |i| %>
+          <% cohort_period_cols.times do |i| %>
             <th style="width: 7.5%; text-align: right;"><%= @conversion_period.titleize %> <%= i + 1 %></th>
           <% end %>
         </tr>
@@ -22,10 +23,10 @@
               <%= row[0] %>
               <div style="font-size: 12px; color: #999;"><%= row[1] == 1 ? "1 user" : "#{number_with_delimiter(row[1])} users" %></div>
             </td>
-            <% 12.times do |i| %>
+            <% cohort_period_cols.times do |i| %>
               <td style="text-align: right;">
                 <% num = row[i + 2] %>
-                <% if num %>
+                <% if num && !num.zero? %>
                   <% denom = row[1] %>
                   <% if denom > 0 %>
                     <%= (100.0 * num / denom).round %>%

--- a/test/cohort_analysis_test.rb
+++ b/test/cohort_analysis_test.rb
@@ -19,4 +19,13 @@ class CohortAnalysisTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match %{selected="selected" value="week"}, response.body
   end
+
+  def test_week_cohort_analysis
+    query = "SELECT 1 AS user_id, NOW() AS conversion_time /* cohort analysis */"
+    run_query query, query_id: 2
+
+    assert_response :success
+    assert_match "Week 1", response.body
+    refute_match "Week 2", response.body
+  end
 end


### PR DESCRIPTION
This change removes zeros from table so the cohort triangle can be seen easier. Also calculates the number of columns to display instead of hard-coding 12 of them.

Old:
<img width="1184" alt="Screenshot 2024-01-12 at 1 03 34 PM" src="https://github.com/ankane/blazer/assets/1834003/6063b173-ebe7-40b1-b2e7-812d9661ad15">


New:
<img width="1182" alt="Screenshot 2024-01-12 at 1 03 59 PM" src="https://github.com/ankane/blazer/assets/1834003/4c37ae15-be04-4ce0-b062-e9217e6a4349">
