### PR TITLE
POC to close #469 - Establish connection to the correct pool when using a replica

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           database: blazer_test
       - run: bundle exec rake test
+
       - run: bundle exec rake test:postgresql

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,4 @@ jobs:
         with:
           database: blazer_test
       - run: bundle exec rake test
-
       - run: bundle exec rake test:postgresql

--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -11,7 +11,7 @@ module Blazer
             def self.name
               "Blazer::Connection::Adapter#{object_id}"
             end
-            establish_connection(data_source.settings["url"]) if data_source.settings["url"]
+            establish_connection(data_source.sql_establish_connection_param) if data_source.sql_establish_connection_param
           end
       end
 

--- a/lib/blazer/data_source.rb
+++ b/lib/blazer/data_source.rb
@@ -200,7 +200,7 @@ module Blazer
     end
 
     def sql_establish_connection_param
-      settings["sql_establish_connection_param"] || settings["url"]
+      settings["sql_establish_connection_param"]&.to_sym || settings["url"]
     end
 
     protected

--- a/lib/blazer/data_source.rb
+++ b/lib/blazer/data_source.rb
@@ -199,6 +199,10 @@ module Blazer
       end
     end
 
+    def sql_establish_connection_param
+      settings["sql_establish_connection_param"] || settings["url"]
+    end
+
     protected
 
     def adapter_instance

--- a/test/adapters/postgresql_replica_test.rb
+++ b/test/adapters/postgresql_replica_test.rb
@@ -1,0 +1,79 @@
+require_relative "../test_helper"
+
+class PostgresqlTest < ActionDispatch::IntegrationTest
+  include AdapterTest
+
+  def data_source
+    "postgresql"
+  end
+
+  def setup
+    settings = { "data_sources" => { "postgresql" => { "establish_connection_param" => "primary_replica" } } }
+    Blazer.instance_variable_set(:@settings, settings)
+  end
+
+  def test_run
+    assert_result [{"hello" => "world"}], "SELECT 'world' AS hello"
+  end
+
+  def test_audit
+    assert_audit "SELECT $1 AS hello\n\n[\"world\"]", "SELECT {var} AS hello", var: "world"
+  end
+
+  def test_string
+    assert_result [{"hello" => "world"}], "SELECT {var} AS hello", var: "world"
+  end
+
+  def test_integer
+    assert_result [{"hello" => "1"}], "SELECT {var} AS hello", var: "1"
+  end
+
+  def test_float
+    assert_result [{"hello" => "1.5"}], "SELECT {var} AS hello", var: "1.5"
+  end
+
+  def test_time
+    assert_result [{"hello" => "2022-01-01 08:00:00"}], "SELECT {created_at} AS hello", created_at: "2022-01-01 08:00:00"
+  end
+
+  def test_nil
+    assert_result [{"hello" => nil}], "SELECT {var} AS hello", var: ""
+  end
+
+  def test_single_quote
+    assert_result [{"hello" => "'"}], "SELECT {var} AS hello", var: "'"
+  end
+
+  def test_double_quote
+    assert_result [{"hello" => '"'}], "SELECT {var} AS hello", var: '"'
+  end
+
+  def test_backslash
+    assert_result [{"hello" => "\\"}], "SELECT {var} AS hello", var: "\\"
+  end
+
+  def test_multiple_variables
+    assert_result [{"c1" => "one", "c2" => "two", "c3" => "one"}], "SELECT {var} AS c1, {var2} AS c2, {var} AS c3", var: "one", var2: "two"
+  end
+
+  def test_bad_position
+    assert_bad_position "SELECT 'world' AS {var}", var: "hello"
+  end
+
+  def test_bad_position_before
+    assert_error "syntax error at or near \"SELECT$1\"", "SELECT{var}", var: "world"
+  end
+
+  def test_bad_position_after
+    assert_error "syntax error at or near \"456\"\nLINE 1: SELECT $1 456", "SELECT {var}456", var: "world"
+    assert_equal "SELECT $1 456\n\n[\"world\"]", Blazer::Audit.last.statement
+  end
+
+  def test_quoted
+    assert_error "could not determine data type of parameter $1", "SELECT '{var}' AS hello", var: "world"
+  end
+
+  def test_binary_output
+    assert_result [{"bytea" => "\\x68656c6c6f"}], "SELECT 'hello'::bytea"
+  end
+end

--- a/test/internal/config/database.yml
+++ b/test/internal/config/database.yml
@@ -5,4 +5,3 @@ test:
   primary_replica:
     adapter:  postgresql
     database: blazer_test
-    replica: true

--- a/test/internal/config/database.yml
+++ b/test/internal/config/database.yml
@@ -1,3 +1,8 @@
 test:
-  adapter:  postgresql
-  database: blazer_test
+  primary:
+    adapter:  postgresql
+    database: blazer_test
+  primary_replica:
+    adapter:  postgresql
+    database: blazer_test
+    replica: true


### PR DESCRIPTION
closes #469 

Currently, when `establish_connection` is called in `sql_adapter.rb` it connects to the given URL via the primary connection pool.  By passing the config name to `establish_connection` instead of the url, we can avoid this.

I can do more work on this if this is the direction you'd like to go, but wanted to put up a POC first.