### PR TITLE
Using after_initialize in engine

### DIFF
--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -20,7 +20,9 @@ module Blazer
         app.config.assets.precompile << proc { |path| path =~ /\Ablazer\/.+\.(eot|svg|ttf|woff|woff2)\z/ }
         app.config.assets.precompile << proc { |path| path == "blazer/favicon.png" }
       end
+    end
 
+    config.after_initialize do
       Blazer.time_zone ||= Blazer.settings["time_zone"] || Time.zone
       Blazer.audit = Blazer.settings.key?("audit") ? Blazer.settings["audit"] : true
       Blazer.user_name = Blazer.settings["user_name"] if Blazer.settings["user_name"]


### PR DESCRIPTION
Allows users to execute ruby code that consumes classes from app/models or any other portion of their app.

This is particularly helpful for creating smart columns for AR enums. i.e.:

```ruby
 # app/models/account.rb
class Account < ApplicationRecord
  enum state: [:pending, :setup, :succeded, :failed]
end

 # config/blazer.yml
data_sources:
  main:
    smart_columns:
      account_state: <%= Account.states.to_h {|k,v| [v, k.titleize]}.to_json %>
```

Without this change, initialization fails with error "uninitialized constant Account (NameError)".