### PR TITLE
Dup frozen columns array to force encoding in Trilogy

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -44,7 +44,7 @@ module Blazer
 
           # fix for non-ASCII column names and charts
           if adapter_name == "Trilogy"
-            columns.map! { |k| k.dup.force_encoding(Encoding::UTF_8) }
+            columns = columns.map { |k| k.dup.force_encoding(Encoding::UTF_8) }
           end
         rescue => e
           error = e.message.sub(/.+ERROR: /, "")


### PR DESCRIPTION
Closes: https://github.com/ankane/blazer/issues/481

When using the Trilogy adapter and Rails 7.2, I'm getting a frozen array error when running a query. Columns is frozen in Rails 7.2 https://github.com/rails/rails/commit/9652207c6b12ccdfd7067b874f8ceff10c54d2b4. 

Instead of attempting to modify the array, changing to allocate a new one.