### PR TITLE
Add more presets for the start_time / end_time

### DIFF
--- a/app/views/blazer/_variables.html.erb
+++ b/app/views/blazer/_variables.html.erb
@@ -90,7 +90,10 @@
             ranges: {
              "Today": [dateStr(), dateStr()],
              "Last 7 Days": [dateStr(6), dateStr()],
-             "Last 30 Days": [dateStr(29), dateStr()]
+             "Last 30 Days": [dateStr(29), dateStr()],
+             "Last 3 Months": [now.clone().subtract(3, "months").format(format), dateStr()],
+             "Last 6 Months": [now.clone().subtract(6, "months").format(format), dateStr()],
+             "Last Year": [now.clone().subtract(1, "year").format(format), dateStr()]
             },
             locale: {
               format: format


### PR DESCRIPTION
I guess this is a personal choice, but I found useful to have a broader selection of presets. Is this something you'd accept?

<img width="689" alt="Screenshot 2025-02-15 at 20 48 59" src="https://github.com/user-attachments/assets/328be071-6c33-4c4f-aaa4-84be46b2f0e2" />
