### PR TITLE
Added support for in-statement variable annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ Use `{start_time}` and `{end_time}` for time ranges. [Example](https://blazer.do
 SELECT * FROM ratings WHERE rated_at >= {start_time} AND rated_at <= {end_time}
 ```
 
+#### Variables with static values (via user selection)
+
+```sql
+-- gender: ["male", "female", "others"]
+-- gender: {"Handsome Male": "male", "Beautiful Women": "female", "Kind Person": "others"}
+
+SELECT * FROM users WHERE gender = {gender}
+```
+
+This allows to annotate regular variables so the UI shows the values as a
+select input instead of a free-text input.
+
 ### Smart Variables
 
 [Example](https://blazer.dokkuapp.com/queries/1-smart-variable)

--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -37,6 +37,7 @@ module Blazer
     def process_vars(statement, var_params = nil)
       var_params ||= request.query_parameters
       (@bind_vars ||= []).concat(statement.variables).uniq!
+      @bind_vars_values ||= statement.variable_values
       # update in-place so populated in view and consistent across queries on dashboard
       @bind_vars.each do |var|
         if !var_params[var]

--- a/app/views/blazer/_variables.html.erb
+++ b/app/views/blazer/_variables.html.erb
@@ -67,7 +67,16 @@
           })()
         <% end %>
       <% else %>
-        <%= text_field_tag var, var_params[var], style: "width: 120px; margin-right: 20px;", autofocus: i == 0 && !var.end_with?("_at") && !var_params[var], class: "form-control" %>
+        <% if @bind_vars_values.key? var %>
+          <%= select_tag var, options_for_select([[nil, nil]] + @bind_vars_values[var], selected: var_params[var]), style: "margin-right: 20px; width: 200px; display: none;" %>
+          <%= javascript_tag nonce: true do %>
+            $("#<%= var %>").selectize({
+              create: true
+            });
+          <% end %>
+        <% else %>
+          <%= text_field_tag var, var_params[var], style: "width: 120px; margin-right: 20px;", autofocus: i == 0 && !var.end_with?("_at") && !var_params[var], class: "form-control" %>
+        <% end %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
First things first: thank you all very much for this awesome gem! :pray: 

**- What is it good for**

In my company and use case, the people who write and maintain queries in Blazer are not the ones running them, and neither of these groups maintains the Blazer configuration or deploys the application. Smart variables would be useful, but they require configuration changes and deployments. Simple variables are great, but they result in free-text inputs. The people running the queries are not always technical, so it would be helpful if we could annotate variable values so that, instead of free-text inputs, they see select boxes with valid options.

This PR adds a solution for this:

<img width="666" height="328" alt="Screenshot_20251202_113229" src="https://github.com/user-attachments/assets/314baf4a-fec8-46e3-8ae7-28d9d011c812" />

**- What I did**

I just added a `Blazer::Statement#variable_values` method which searches for comments on the statement in a particular format, tries to parse them as JSON, and uses them for displaying on the UI. 

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="299" height="168" alt="image" src="https://github.com/user-attachments/assets/192bc822-fb15-4728-abcf-d118d7a9a61b" />


