### PR TITLE
Add catalog support to Athena adapter

### DIFF
--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -32,9 +32,7 @@ module Blazer
             query_string: statement,
             # use token so we fetch cached results after query is run
             client_request_token: request_token,
-            query_execution_context: {
-              database: database
-            }
+            query_execution_context: query_execution_context
           }
 
           if settings["output_location"]
@@ -119,11 +117,11 @@ module Blazer
       end
 
       def tables
-        glue.get_tables(database_name: database).table_list.map(&:name).sort
+        glue_get_tables.table_list.map(&:name).sort
       end
 
       def schema
-        glue.get_tables(database_name: database).table_list.map { |t| {table: t.name, columns: t.storage_descriptor.columns.map { |c| {name: c.name, data_type: c.type} }} }
+        glue_get_tables.table_list.map { |t| {table: t.name, columns: t.storage_descriptor.columns.map { |c| {name: c.name, data_type: c.type} }} }
       end
 
       def preview_statement
@@ -141,6 +139,18 @@ module Blazer
       end
 
       private
+
+      def catalog
+        settings["catalog"]
+      end
+
+      def query_execution_context
+        {database: database, catalog: catalog}.compact
+      end
+
+      def glue_get_tables
+        glue.get_tables({database_name: database, catalog_id: catalog}.compact)
+      end
 
       def database
         @database ||= settings["database"] || "default"

--- a/test/adapters/athena_test.rb
+++ b/test/adapters/athena_test.rb
@@ -65,9 +65,25 @@ class AthenaTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_catalog_in_query_execution_context
+    adapter = build_adapter("catalog" => "s3tablescatalog/my-datalake", "database" => "starview")
+    context = {database: "starview", catalog: "s3tablescatalog/my-datalake"}
+    assert_equal context, adapter.send(:query_execution_context)
+  end
+
+  def test_catalog_omitted_when_not_set
+    adapter = build_adapter("database" => "mydb")
+    assert_equal({database: "mydb"}, adapter.send(:query_execution_context))
+  end
+
   private
 
   def engine_version
     Blazer.data_sources[data_source].settings["engine_version"].to_i
+  end
+
+  def build_adapter(settings)
+    data_source = OpenStruct.new(settings: settings, id: "test", timeout: 300)
+    Blazer::Adapters::AthenaAdapter.new(data_source)
   end
 end


### PR DESCRIPTION
Allow setting a `catalog` in blazer.yml for Athena data sources to support non-default catalogs (e.g. S3 Table Catalog). Passes catalog to both Athena query_execution_context and Glue get_tables calls.