### PR TITLE
Add optional permission hooks (can_create_blazer_queries?, can_access_blazer_query?)

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -121,6 +121,30 @@ module Blazer
     end
     helper_method :blazer_user
 
+    def can_create_blazer_queries?
+      return true unless blazer_user.respond_to?(:can_create_blazer_queries?)
+      blazer_user.can_create_blazer_queries?
+    end
+    helper_method :can_create_blazer_queries?
+
+    def can_access_blazer_query?(query)
+      return true unless blazer_user.respond_to?(:can_access_blazer_query?)
+      blazer_user.can_access_blazer_query?(query)
+    end
+    helper_method :can_access_blazer_query?
+
+    def authorize_blazer_create!
+      render_forbidden unless can_create_blazer_queries?
+    end
+
+    def authorize_blazer_query_access!
+      render_forbidden unless can_access_blazer_query?(@query)
+    end
+
+    def render_forbidden
+      render plain: "Access denied", status: :forbidden
+    end
+
     def render_errors(resource)
       @errors = resource.errors
       action = resource.persisted? ? :edit : :new

--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -133,12 +133,22 @@ module Blazer
     end
     helper_method :can_access_blazer_query?
 
+    def can_access_blazer_dashboard?(dashboard)
+      return true unless blazer_user.respond_to?(:can_access_blazer_dashboard?)
+      blazer_user.can_access_blazer_dashboard?(dashboard)
+    end
+    helper_method :can_access_blazer_dashboard?
+
     def authorize_blazer_create!
       render_forbidden unless can_create_blazer_queries?
     end
 
     def authorize_blazer_query_access!
       render_forbidden unless can_access_blazer_query?(@query)
+    end
+
+    def authorize_blazer_dashboard_access!
+      render_forbidden unless can_access_blazer_dashboard?(@dashboard)
     end
 
     def render_forbidden

--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -1,6 +1,7 @@
 module Blazer
   class ChecksController < BaseController
     before_action :set_check, only: [:edit, :update, :destroy, :run]
+    before_action :authorize_blazer_create!, only: [:new, :create, :edit, :update, :destroy]
 
     def index
       state_order = [nil, "disabled", "error", "timed out", "failing", "passing"]

--- a/app/controllers/blazer/dashboards_controller.rb
+++ b/app/controllers/blazer/dashboards_controller.rb
@@ -1,6 +1,7 @@
 module Blazer
   class DashboardsController < BaseController
     before_action :set_dashboard, only: [:show, :edit, :update, :destroy, :refresh]
+    before_action :authorize_blazer_dashboard_access!, only: [:show, :edit, :update, :destroy, :refresh]
     before_action :authorize_blazer_create!, only: [:new, :create, :edit, :update, :destroy]
 
     def new

--- a/app/controllers/blazer/dashboards_controller.rb
+++ b/app/controllers/blazer/dashboards_controller.rb
@@ -1,6 +1,7 @@
 module Blazer
   class DashboardsController < BaseController
     before_action :set_dashboard, only: [:show, :edit, :update, :destroy, :refresh]
+    before_action :authorize_blazer_create!, only: [:new, :create, :edit, :update, :destroy]
 
     def new
       @dashboard = Blazer::Dashboard.new

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -2,7 +2,7 @@ module Blazer
   class QueriesController < BaseController
     before_action :set_query, only: [:show, :edit, :update, :destroy, :refresh]
     before_action :authorize_blazer_query_access!, only: [:show, :edit, :update, :destroy, :refresh]
-    before_action :authorize_blazer_create!, only: [:new, :create]
+    before_action :authorize_blazer_create!, only: [:new, :create, :edit, :update, :destroy]
     before_action :set_data_source, only: [:tables, :docs, :schema, :cancel]
 
     def home

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -1,6 +1,8 @@
 module Blazer
   class QueriesController < BaseController
     before_action :set_query, only: [:show, :edit, :update, :destroy, :refresh]
+    before_action :authorize_blazer_query_access!, only: [:show, :edit, :update, :destroy, :refresh]
+    before_action :authorize_blazer_create!, only: [:new, :create]
     before_action :set_data_source, only: [:tables, :docs, :schema, :cancel]
 
     def home
@@ -343,6 +345,7 @@ module Blazer
       @more = limit && @queries.size >= limit
 
       @queries = @queries.select { |q| !q.name.to_s.start_with?("#") || q.try(:creator).try(:id) == blazer_user.try(:id) }
+      @queries = @queries.select { |q| can_access_blazer_query?(q) }
 
       @queries =
         @queries.map do |q|
@@ -365,10 +368,6 @@ module Blazer
 
     def set_query
       @query = Blazer::Query.find(params[:id].to_s.split("-").first)
-    end
-
-    def render_forbidden
-      render plain: "Access denied", status: :forbidden
     end
 
     def query_params

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -15,6 +15,8 @@ module Blazer
         @dashboards = @dashboards.includes(:creator) if Blazer.user_class
       end
 
+      @dashboards = @dashboards.select { |d| can_access_blazer_dashboard?(d) }
+
       @dashboards =
         @dashboards.map do |d|
           {

--- a/app/views/blazer/_nav.html.erb
+++ b/app/views/blazer/_nav.html.erb
@@ -9,10 +9,12 @@
     <% if Blazer.uploads? %>
       <li><%= link_to "Uploads", uploads_path %></li>
     <% end %>
-    <li role="separator" class="divider"></li>
-    <li><%= link_to "New Query", new_query_path %></li>
-    <li><%= link_to "New Dashboard", new_dashboard_path %></li>
-    <% check_params = @query ? {query_id: @query.id} : {} %>
-    <li><%= link_to "New Check", new_check_path(check_params) %></li>
+    <% if can_create_blazer_queries? %>
+      <li role="separator" class="divider"></li>
+      <li><%= link_to "New Query", new_query_path %></li>
+      <li><%= link_to "New Dashboard", new_dashboard_path %></li>
+      <% check_params = @query ? {query_id: @query.id} : {} %>
+      <li><%= link_to "New Check", new_check_path(check_params) %></li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/blazer/dashboards/_form.html.erb
+++ b/app/views/blazer/dashboards/_form.html.erb
@@ -22,7 +22,7 @@
     <%= select_tag :query_id, nil, {include_blank: true, placeholder: "Select chart"} %>
   </div>
   <p style="padding-bottom: 140px;" v-cloak>
-    <% if @dashboard.persisted? %>
+    <% if @dashboard.persisted? && can_create_blazer_queries? %>
       <%= link_to "Delete", dashboard_path(@dashboard), method: :delete, "data-confirm" => "Are you sure?", class: "btn btn-danger" %>
     <% end %>
     <%= f.submit "Save", class: "btn btn-success" %>

--- a/app/views/blazer/dashboards/show.html.erb
+++ b/app/views/blazer/dashboards/show.html.erb
@@ -10,7 +10,9 @@
         </h3>
       </div>
       <div class="col-sm-3 text-right">
-        <%= link_to "Edit", edit_dashboard_path(@dashboard, params: variable_params(@dashboard)), class: "btn btn-info" %>
+        <% if can_create_blazer_queries? %>
+          <%= link_to "Edit", edit_dashboard_path(@dashboard, params: variable_params(@dashboard)), class: "btn btn-info" %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/blazer/queries/_form.html.erb
+++ b/app/views/blazer/queries/_form.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="form-group text-right">
           <%= f.submit "For Enter Press", class: "hide" %>
-          <% if @query.persisted? %>
+          <% if @query.persisted? && can_create_blazer_queries? %>
             <%= link_to "Delete", query_path(@query), method: :delete, "data-confirm" => "Are you sure?", class: "btn btn-danger" %>
             <%= f.submit "Fork", class: "btn btn-info" %>
           <% end %>

--- a/app/views/blazer/queries/home.html.erb
+++ b/app/views/blazer/queries/home.html.erb
@@ -11,22 +11,24 @@
         <%= link_to "Mine", root_path(filter: "mine"), class: params[:filter] == "mine" ? "active" : nil, style: "margin-right: 40px;" %>
       <% end %>
 
-      <div class="btn-group">
-        <%= link_to "New Query", new_query_path, class: "btn btn-info" %>
-        <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <span class="caret"></span>
-          <span class="sr-only">Toggle Dropdown</span>
-        </button>
-        <ul class="dropdown-menu">
-          <li><%= link_to "Checks", checks_path %></li>
-          <% if Blazer.uploads? %>
-            <li><%= link_to "Uploads", uploads_path %></li>
-          <% end %>
-          <li role="separator" class="divider"></li>
-          <li><%= link_to "New Dashboard", new_dashboard_path %></li>
-          <li><%= link_to "New Check", new_check_path %></li>
-        </ul>
-      </div>
+      <% if can_create_blazer_queries? %>
+        <div class="btn-group">
+          <%= link_to "New Query", new_query_path, class: "btn btn-info" %>
+          <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="caret"></span>
+            <span class="sr-only">Toggle Dropdown</span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><%= link_to "Checks", checks_path %></li>
+            <% if Blazer.uploads? %>
+              <li><%= link_to "Uploads", uploads_path %></li>
+            <% end %>
+            <li role="separator" class="divider"></li>
+            <li><%= link_to "New Dashboard", new_dashboard_path %></li>
+            <li><%= link_to "New Check", new_check_path %></li>
+          </ul>
+        </div>
+      <% end %>
     </div>
     <input type="text" v-model="searchTerm" placeholder="Start typing a query, dashboard, or person" style="width: 300px; display: inline-block;" v-focus class="search form-control" />
   </div>

--- a/app/views/blazer/queries/show.html.erb
+++ b/app/views/blazer/queries/show.html.erb
@@ -10,8 +10,10 @@
         </h3>
       </div>
       <div class="col-sm-3 text-right">
-        <%= link_to "Edit", edit_query_path(@query, params: variable_params(@query)), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
-        <%= link_to "Fork", new_query_path(params: {variables: variable_params(@query), fork_query_id: @query.id, data_source: @query.data_source, name: @query.name}), class: "btn btn-info" %>
+        <% if can_create_blazer_queries? %>
+          <%= link_to "Edit", edit_query_path(@query, params: variable_params(@query)), class: "btn btn-default", disabled: !@query.editable?(blazer_user) %>
+          <%= link_to "Fork", new_query_path(params: {variables: variable_params(@query), fork_query_id: @query.id, data_source: @query.data_source, name: @query.name}), class: "btn btn-info" %>
+        <% end %>
 
         <% if !@error && @success %>
           <%= button_to "Download", run_queries_path(format: "csv"), params: @run_data, class: "btn btn-primary" %>


### PR DESCRIPTION
## Summary

Adds two optional, backwards-compatible permission hooks so host applications can gate Blazer actions on a per-user and per-query basis:

- `can_create_blazer_queries?` — controls create/edit/update/destroy access across queries, dashboards, and checks.
- `can_access_blazer_query?(query)` — controls per-query read access (show, edit, update, destroy, refresh, and the home page listing).

Both hooks delegate to the `blazer_user` object **only when the method is defined**, so existing Blazer installs (whose `blazer_user` doesn't implement these methods) behave exactly as they do today.

## Motivation

In a multi-tenant / multi-team Rails app we wanted to let non-admin users reach Blazer while restricting:

- who can author queries (writers vs. read-only viewers)
- which queries each viewer can even see (per-team dashboards, sensitive data, etc.)

Today a host app has to monkey-patch Blazer controllers or duplicate Blazer behind an outer gate to do either. The hook surface here is small enough that it can live upstream without adding any new concept for existing users.

## Behavior when the host app does nothing

```ruby
# base_controller.rb
def can_create_blazer_queries?
  return true unless blazer_user.respond_to?(:can_create_blazer_queries?)
  blazer_user.can_create_blazer_queries?
end

def can_access_blazer_query?(query)
  return true unless blazer_user.respond_to?(:can_access_blazer_query?)
  blazer_user.can_access_blazer_query?(query)
end
```

If the host app's user class doesn't define either method, both hooks return `true` — identical to today's unrestricted behavior.

## Where the hooks are wired in

| Controller / View | Gate |
|---|---|
| `QueriesController` `show/edit/update/destroy/refresh` | `authorize_blazer_query_access!` → `can_access_blazer_query?(@query)` |
| `QueriesController` `new/create/edit/update/destroy` | `authorize_blazer_create!` → `can_create_blazer_queries?` |
| `DashboardsController` `new/create/edit/update/destroy` | `authorize_blazer_create!` |
| `ChecksController` `new/create/edit/update/destroy` | `authorize_blazer_create!` |
| Home page query listing | filtered via `select { can_access_blazer_query?(q) }` |
| Nav / `queries#show` / `queries/_form` / `dashboards#show` / `dashboards/_form` | `<% if can_create_blazer_queries? %>` wraps New/Edit/Delete/Fork buttons |

## Host-app example

```ruby
class User < ApplicationRecord
  def can_create_blazer_queries?
    admin?
  end

  def can_access_blazer_query?(query)
    return true if admin?

    # e.g. allow any query whose name starts with `[team]` to members of that team
    team_prefix = "[#{team.name}]"
    query.name.to_s.start_with?(team_prefix)
  end
end
```

## Backwards compatibility

- Both hooks are wrapped in `respond_to?` checks and default to `true` when the user class doesn't implement them.
- No new gem config required.
- No schema changes.
- Existing test suite should continue to pass (no specs opted into the new hooks).

Happy to iterate on naming, placement, or behavior — feedback welcome.