### PR TITLE
Avoid SassC evaluating CSS max() with custom properties

### DIFF
--- a/app/assets/stylesheets/blazer/tom-select.css
+++ b/app/assets/stylesheets/blazer/tom-select.css
@@ -225,7 +225,7 @@
   cursor: pointer;
 }
 .plugin-clear_button.form-select .clear-button, .plugin-clear_button.single .clear-button {
-  right: max(var(--ts-pr-caret), 8px);
+  right: Max(var(--ts-pr-caret), 8px);
 }
 .plugin-clear_button.focus.has-items .clear-button, .plugin-clear_button:not(.disabled):hover.has-items .clear-button {
   opacity: 1;
@@ -373,11 +373,11 @@
 }
 
 .ts-control:not(.rtl) {
-  padding-right: max(var(--ts-pr-min), var(--ts-pr-clear-button) + var(--ts-pr-caret)) !important;
+  padding-right: Max(var(--ts-pr-min), calc(var(--ts-pr-clear-button) + var(--ts-pr-caret))) !important;
 }
 
 .ts-control.rtl {
-  padding-left: max(var(--ts-pr-min), var(--ts-pr-clear-button) + var(--ts-pr-caret)) !important;
+  padding-left: Max(var(--ts-pr-min), calc(var(--ts-pr-clear-button) + var(--ts-pr-caret))) !important;
 }
 
 .ts-wrapper {


### PR DESCRIPTION
This fixes SassC compilation errors when CSS custom properties are used inside native CSS math functions.

SassC attempts to evaluate `max()` as a Sass function and raises errors such as:

"var(--ts-pr-caret)" is not a number for `max`

This change preserves the intended browser behavior while avoiding SassC evaluation at build time.

This updates CSS `max()` calls that include CSS custom properties so they are emitted as native CSS functions instead of being evaluated by SassC at compile time.

