### PR TITLE
Add missing sql aliases 

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -75,7 +75,7 @@ module Blazer
           if sqlite?
             "SELECT NULL, name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name"
           elsif postgresql?
-            add_schemas("SELECT * FROM (SELECT table_schema, table_name FROM information_schema.tables UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name FROM pg_class c INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relkind = 'm' AND has_any_column_privilege(c.oid, 'SELECT'))")
+            add_schemas("SELECT * FROM (SELECT table_schema, table_name FROM information_schema.tables UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name FROM pg_class c INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relkind = 'm' AND has_any_column_privilege(c.oid, 'SELECT')) AS subquery")
           else
             add_schemas("SELECT table_schema, table_name FROM information_schema.tables")
           end
@@ -106,7 +106,7 @@ module Blazer
           if sqlite?
             "SELECT NULL, t.name, c.name, c.type, c.cid FROM sqlite_master t INNER JOIN pragma_table_info(t.name) c WHERE t.type IN ('table', 'view')"
           elsif postgresql?
-            add_schemas("SELECT * FROM (SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name, a.attname AS column_name, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnum AS ordinal_position FROM pg_attribute a INNER JOIN pg_class c ON a.attrelid = c.oid INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relkind = 'm' AND has_column_privilege(c.oid, a.attnum, 'SELECT'))")
+            add_schemas("SELECT * FROM (SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name, a.attname AS column_name, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnum AS ordinal_position FROM pg_attribute a INNER JOIN pg_class c ON a.attrelid = c.oid INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relkind = 'm' AND has_column_privilege(c.oid, a.attnum, 'SELECT')) AS subquery")
           else
             add_schemas("SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns")
           end


### PR DESCRIPTION
After upgrading from 3.3 we're getting this error that is nor surfaced anywhere because `def tables` doesn't check errors and returns an empty array instead:
```
=> " subquery in FROM must have an alias\nLINE 1: SELECT * FROM (SELECT table_schema, table_name FROM informat...\n                      ^\nHINT:  For example, FROM (SELECT ...) [AS] foo.\n"
```


Tests are actually failing without this fix:

```
  1) Failure:
PostgresqlTest#test_tables_method [test/adapters/postgresql_test.rb:28]:
Expected [] to include "users".

  2) Failure:
PostgresqlTest#test_schema_method [test/adapters/postgresql_test.rb:40]:
--- expected
+++ actual
@@ -1 +1 @@
-[{name: "id", data_type: "bigint"}, {name: "name", data_type: "character varying"}]
+nil
```