### PR TITLE
Update the postgres query so that it works for earlier PG versions

### DIFF
--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -106,7 +106,7 @@ module Blazer
           if sqlite?
             "SELECT NULL, t.name, c.name, c.type, c.cid FROM sqlite_master t INNER JOIN pragma_table_info(t.name) c WHERE t.type IN ('table', 'view')"
           elsif postgresql?
-            add_schemas("SELECT * FROM (SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name, a.attname AS column_name, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnum AS ordinal_position FROM pg_attribute a INNER JOIN pg_class c ON a.attrelid = c.oid INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relkind = 'm' AND has_column_privilege(c.oid, a.attnum, 'SELECT'))")
+            add_schemas("SELECT * FROM (SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name, a.attname AS column_name, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnum AS ordinal_position FROM pg_attribute a INNER JOIN pg_class c ON a.attrelid = c.oid INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relkind = 'm' AND has_column_privilege(c.oid, a.attnum, 'SELECT')) as extracted_table_list")
           else
             add_schemas("SELECT table_schema, table_name, column_name, data_type, ordinal_position FROM information_schema.columns")
           end

--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -75,7 +75,7 @@ module Blazer
           if sqlite?
             "SELECT NULL, name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name"
           elsif postgresql?
-            add_schemas("SELECT * FROM (SELECT table_schema, table_name FROM information_schema.tables UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name FROM pg_class c INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relkind = 'm' AND has_any_column_privilege(c.oid, 'SELECT'))")
+            add_schemas("SELECT * FROM (SELECT table_schema, table_name FROM information_schema.tables UNION ALL SELECT n.nspname AS table_schema, c.relname AS table_name FROM pg_class c INNER JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relkind = 'm' AND has_any_column_privilege(c.oid, 'SELECT')) as extracted_table_list")
           else
             add_schemas("SELECT table_schema, table_name FROM information_schema.tables")
           end


### PR DESCRIPTION
This pull request makes small but important changes to SQL query generation for PostgreSQL in the `Blazer` SQL adapter. The main update is the addition of an alias (`as extracted_table_list`) to subqueries in both the `tables` and `schema` methods. This improves SQL compatibility and clarity, especially for databases like PostgreSQL that require subquery aliases.

**PostgreSQL Query Compatibility Improvements:**

* Added an alias (`as extracted_table_list`) to the subquery in the `tables` method for PostgreSQL to ensure proper SQL syntax and compatibility. (`lib/blazer/adapters/sql_adapter.rb`, [lib/blazer/adapters/sql_adapter.rbL78-R78](diffhunk://#diff-5c586b9e5b4cf610437607018afe726a8f0bf58f3a561446a22de9db0dfbf926L78-R78))
* Added an alias (`as extracted_table_list`) to the subquery in the `schema` method for PostgreSQL to ensure proper SQL syntax and compatibility. (`lib/blazer/adapters/sql_adapter.rb`, [lib/blazer/adapters/sql_adapter.rbL109-R109](diffhunk://#diff-5c586b9e5b4cf610437607018afe726a8f0bf58f3a561446a22de9db0dfbf926L109-R109))