### PR TITLE
Restore data-method link handling

### DIFF
--- a/app/assets/javascripts/blazer/application.js
+++ b/app/assets/javascripts/blazer/application.js
@@ -54,12 +54,52 @@ document.addEventListener("click", function (e) {
 })
 
 document.addEventListener("click", function (e) {
-  const target = e.target.closest("a[data-confirm]")
-  if (target) {
-    if (!window.confirm(target.getAttribute("data-confirm"))) {
-      e.preventDefault()
-    }
+  const target = e.target.closest("a[data-confirm], a[data-method]")
+  if (!target) return
+
+  const confirmMessage = target.getAttribute("data-confirm")
+
+  if (confirmMessage && !window.confirm(confirmMessage)) {
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    return
   }
+
+  const method = target.getAttribute("data-method")
+  if (!method) return
+
+  e.preventDefault()
+  e.stopImmediatePropagation()
+
+  const form = document.createElement("form")
+  form.method = "post"
+  form.action = target.href
+  form.hidden = true
+
+  if (target.target) {
+    form.target = target.target
+  }
+
+  const methodInput = document.createElement("input")
+  methodInput.type = "hidden"
+  methodInput.name = "_method"
+  methodInput.value = method
+  form.appendChild(methodInput)
+
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+  const csrfParam = document.querySelector('meta[name="csrf-param"]')?.getAttribute("content")
+  const url = new URL(target.href, window.location.href)
+
+  if (csrfToken && csrfParam && url.origin === window.location.origin) {
+    const csrfInput = document.createElement("input")
+    csrfInput.type = "hidden"
+    csrfInput.name = csrfParam
+    csrfInput.value = csrfToken
+    form.appendChild(csrfInput)
+  }
+
+  document.body.appendChild(form)
+  form.submit()
 })
 
 // make autofocus work with back button


### PR DESCRIPTION
Restores support for links with `data-method` after the removal of `rails-ujs`.

The new click handler creates and submits a temporary hidden form with the requested HTTP method and CSRF token, preserving the previous full-page navigation behavior without reintroducing the `rails-ujs` dependency.

It also handles `data-confirm` in the same listener, ensuring that cancelling the confirmation prevents the request from being submitted.

Tested locally against a Rails app using Turbo upgrading from blazer 3.3.0 → 3.5.0 (which surfaced the regression) — with this change, Delete correctly issues a `DELETE` request and removes the record.

Fixes #526